### PR TITLE
chore: TypeScript 빌드 통과를 위한 잡다한 수정

### DIFF
--- a/src/pages/modal_test_view/_components/EditMenuModal.tsx
+++ b/src/pages/modal_test_view/_components/EditMenuModal.tsx
@@ -98,20 +98,6 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
     setStock(String(clamped));
   };
 
-  const handleRemoveImage = (e?: React.MouseEvent<HTMLButtonElement>) => {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-    if (UploadImg) {
-      URL.revokeObjectURL(UploadImg);
-    }
-    setUploadImg(null);
-    setImage(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 

--- a/src/pages/modal_test_view/_components/EditSetMenuModal.tsx
+++ b/src/pages/modal_test_view/_components/EditSetMenuModal.tsx
@@ -108,19 +108,6 @@ const EditSetMenuModal = ({
     setPrice(String(clamped));
   };
 
-  const handleRemoveImage = (e?: React.MouseEvent<HTMLButtonElement>) => {
-    if (e) {
-      e.preventDefault();
-      e.stopPropagation();
-    }
-    if (uploadImg) {
-      URL.revokeObjectURL(uploadImg);
-    }
-    setUploadImg(null);
-    if (fileInputRef.current) {
-      fileInputRef.current.value = "";
-    }
-  };
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     if (!name || !price) {

--- a/src/pages/tableView/_components/tableGrid.tsx
+++ b/src/pages/tableView/_components/tableGrid.tsx
@@ -45,7 +45,7 @@ const TableViewGrid: React.FC<Props> = ({ tableList, onSelectTable }) => {
         const viewData: TableOrder = {
           tableNumber: item.tableNum,
           totalAmount: item.amount,
-          orderedAt: formatTime(item.createdAt),
+          orderedAt: formatTime(item.startedAt),
           orders: (item.latestOrders ?? []).map((o) => ({
             menu: o.name,
             quantity: o.qty,

--- a/src/services/MenuService.ts
+++ b/src/services/MenuService.ts
@@ -6,7 +6,6 @@ import {
   SetMenu,
   TableInfo,
 } from '../pages/menu/Type/Menu_type';
-import { MenuRegistResponse } from './MenuServiceWithImg';
 
 export type MenuListCategoryV3 = 'FEE' | 'MENU' | 'DRINK' | 'SET';
 


### PR DESCRIPTION
- tableGrid: TableItem은 startedAt 사용
- MenuService: 미사용 import 제거
- EditMenu/SetMenuModal: 비활성화된 삭제 버튼용 미사용 핸들러 제거

#19