### PR TITLE
♻️ [Refactor] #14 -  쿠키 이슈 해결 — 프록시 기반 Same-Origin 구조로 전환

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,32 @@
+# ── 프로덕션 배포 (main 브랜치) ─────────────────────────────────────────────
+[context.production]
+[[context.production.redirects]]
+  from = "/api/v3/*"
+  to = "https://prod.dorder-api.shop/api/v3/:splat"
+  status = 200
+  force = true
+
+[[context.production.redirects]]
+  from = "/api/v2/*"
+  to = "https://prod.dorder-api.shop/api/v2/:splat"
+  status = 200
+  force = true
+
+# ── 브랜치/PR 미리보기 (develop 등) ─────────────────────────────────────────
+[context.deploy-preview]
+[[context.deploy-preview.redirects]]
+  from = "/api/v3/*"
+  to = "https://dev.dorder-api.shop/api/v3/:splat"
+  status = 200
+  force = true
+
+[[context.deploy-preview.redirects]]
+  from = "/api/v2/*"
+  to = "https://dev.dorder-api.shop/api/v2/:splat"
+  status = 200
+  force = true
+
+# ── SPA 라우팅 (공통) ────────────────────────────────────────────────────────
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/src/components/header/hooks/useStaffCall.ts
+++ b/src/components/header/hooks/useStaffCall.ts
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { AxiosError } from "axios";
-import { instance } from "@services/instance";
+import { instanceV2 } from "@services/instance";
 import { BellPlayer } from "../BellPlayer";
 
 interface Notification {
@@ -25,7 +25,7 @@ export const useStaffCall = () => {
 
     const fetchInitialNotifications = async () => {
       try {
-        const response = await instance.get<{
+        const response = await instanceV2.get<{
           status: string;
           data: ApiCallStaff[];
         }>("/api/v2/booth/staff-calls/");

--- a/src/pages/dashboard/_services/dashboard.api.ts
+++ b/src/pages/dashboard/_services/dashboard.api.ts
@@ -1,5 +1,5 @@
 // src/pages/Dashboard/_services/dashboard.api.ts
-import { instance } from "@services/instance";
+import { instanceV2 } from "@services/instance";
 import type { DashboardResponse } from "./dashboard.types";
 
 const REST_ENDPOINT = "/api/v2/statistic/";
@@ -17,7 +17,7 @@ function getBoothIdStrict(): string {
 export async function fetchDashboard(): Promise<DashboardResponse> {
   const boothId = getBoothIdStrict();
 
-  const res = await instance.get(REST_ENDPOINT, {
+  const res = await instanceV2.get(REST_ENDPOINT, {
     headers: { "Booth-ID": boothId },
   });
 

--- a/src/pages/liveorder_v2/services/LiveOrderServiceV2.ts
+++ b/src/pages/liveorder_v2/services/LiveOrderServiceV2.ts
@@ -1,4 +1,4 @@
-import { instance } from "../../../services/instance";
+import { instanceV2 } from "../../../services/instance";
 import { OrderStatus } from "../types";
 
 /**
@@ -7,7 +7,7 @@ import { OrderStatus } from "../types";
  */
 export const getMenuNames = async (): Promise<string[]> => {
   try {
-    const response = await instance.get<{ data: string[] }>(
+    const response = await instanceV2.get<{ data: string[] }>(
       "api/v2/booth/menu-names/"
     );
     return response.data.data;
@@ -25,7 +25,7 @@ export const updateOrderToCooked = async (
   ordermenuId: number
 ): Promise<void> => {
   const body = { type: "menu", id: ordermenuId };
-  await instance.post("api/v2/booth/kitchen/orders/", body);
+  await instanceV2.post("api/v2/booth/kitchen/orders/", body);
 };
 
 /**
@@ -36,7 +36,7 @@ export const updateOrderToServed = async (
   ordermenuId: number
 ): Promise<void> => {
   const body = { type: "menu", id: ordermenuId };
-  await instance.post("api/v2/booth/serving/orders/", body);
+  await instanceV2.post("api/v2/booth/serving/orders/", body);
 };
 
 /**
@@ -49,5 +49,5 @@ export const revertOrderStatus = async (
   targetStatus: OrderStatus
 ): Promise<void> => {
   const body = { id: ordermenuId, target_status: targetStatus };
-  await instance.patch("api/v2/booth/revert/orders/", body);
+  await instanceV2.patch("api/v2/booth/revert/orders/", body);
 };

--- a/src/services/CouponService.ts
+++ b/src/services/CouponService.ts
@@ -1,4 +1,4 @@
-import { instance } from './instance';
+import { instance, instanceV2 } from './instance';
 
 export interface postNewCouponRequest {
   name: string;
@@ -102,12 +102,12 @@ export const CouponService = {
     }
   },
 
-  // V3 미제공 엔드포인트 — 기존 v2 유지
+  // V3 미제공 엔드포인트 — 기존 v2 유지 (v3 API 추가 시 instanceV2 → instance로 교체)
   getCouponDetail: async (
     coupon_id: number,
   ): Promise<getCouponDetailResponse> => {
     try {
-      const response = await instance.get<getCouponDetailResponse>(
+      const response = await instanceV2.get<getCouponDetailResponse>(
         `/api/v2/coupons/${coupon_id}/`,
       );
       return response.data;
@@ -116,12 +116,12 @@ export const CouponService = {
     }
   },
 
-  // V3 미제공 엔드포인트 — 기존 v2 유지
+  // V3 미제공 엔드포인트 — 기존 v2 유지 (v3 API 추가 시 instanceV2 → instance로 교체)
   getCouponDetailCodeList: async (
     coupon_id: number,
   ): Promise<getCouponCodeListResponse> => {
     try {
-      const response = await instance.get<getCouponCodeListResponse>(
+      const response = await instanceV2.get<getCouponCodeListResponse>(
         `/api/v2/coupons/${coupon_id}/codes/`,
       );
       return response.data;

--- a/src/services/UserService.ts
+++ b/src/services/UserService.ts
@@ -1,5 +1,5 @@
 import { isAxiosError } from 'axios';
-import { instance } from './instance';
+import { instance, instanceV2 } from './instance';
 
 export interface SignupRequest {
   username: string;
@@ -99,7 +99,7 @@ export interface RefreshResponseV3 {
 
 const UserService = {
   postSignup: async (data: SignupRequest) => {
-    const response = await instance.post('/api/v2/manager/signup/', data);
+    const response = await instanceV2.post('/api/v2/manager/signup/', data);
     return response.data;
   },
 
@@ -120,7 +120,7 @@ const UserService = {
 
   login: async (data: LoginRequest): Promise<LoginResponse> => {
     try {
-      const response = await instance.post('/api/v2/manager/auth/', data);
+      const response = await instanceV2.post('/api/v2/manager/auth/', data);
 
       if (!response.data?.token?.access) {
         throw new Error('로그인 응답이 올바르지 않습니다.');

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -6,10 +6,11 @@ import axios, {
 } from 'axios';
 import UserService from './UserService';
 
+// V3 인스턴스: 상대경로 baseURL → vite proxy(로컬) / netlify redirect(배포) 경유
+// 쿠키 기반 인증, SameSite=Lax 호환
 export const instance: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL,
+  baseURL: '/',
   withCredentials: true,
-  // 👇 Axios가 자동으로 csrftoken 쿠키를 읽어서 X-CSRFToken 헤더에 넣도록 지시
   xsrfCookieName: 'csrftoken',
   xsrfHeaderName: 'X-CSRFToken',
   headers: {
@@ -17,6 +18,40 @@ export const instance: AxiosInstance = axios.create({
   },
   timeout: 10000,
 });
+
+// V2 인스턴스: 절대경로 baseURL로 직접 요청 (Bearer 토큰 인증, v3 전환 완료 시 제거 예정)
+export const instanceV2: AxiosInstance = axios.create({
+  baseURL: (import.meta.env.VITE_BASE_URL ?? '').replace(/\/+$/, ''),
+  withCredentials: false,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+  timeout: 10000,
+});
+
+// V2 요청 인터셉터: Bearer 토큰 주입 (로그인/회원가입 제외)
+instanceV2.interceptors.request.use((config) => {
+  const token = localStorage.getItem('accessToken');
+  const isV2AuthEndpoint =
+    config.url?.includes('/api/v2/manager/auth/') ||
+    config.url?.includes('/api/v2/manager/signup/');
+  if (token && !isV2AuthEndpoint) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
+// V2 응답 인터셉터: 401 → 로그인 리다이렉트 (v2는 refresh 없이 바로 이동)
+instanceV2.interceptors.response.use(
+  (res) => res,
+  (error: AxiosError) => {
+    if (error.response?.status === 401) {
+      localStorage.removeItem('accessToken');
+      window.location.href = '/login';
+    }
+    return Promise.reject(error);
+  },
+);
 
 const isAuthEndpoint = (url?: string) =>
   url?.includes('/api/v2/manager/auth/') ||
@@ -192,7 +227,8 @@ instance.interceptors.response.use(
           processQueue(null, null);
           return instance(originalRequest);
         } else {
-          const res = await instance.get('/api/v2/manager/auth/');
+          // v2는 instanceV2로 직접 호출 (instance는 이제 v3 전용 상대경로)
+          const res = await instanceV2.get('/api/v2/manager/auth/');
           const newAccessToken = res.data?.data?.access;
           if (!newAccessToken) throw new Error('토큰이 응답에 없습니다.');
 
@@ -244,10 +280,10 @@ instance.interceptors.response.use(
 );
 
 // 이미지 인스턴스도 동일하게 추가해 줍니다.
+// V3 이미지 업로드 인스턴스: instance와 동일하게 상대경로 baseURL
 export const instatnceWithImg: AxiosInstance = axios.create({
-  baseURL: import.meta.env.VITE_BASE_URL,
+  baseURL: '/',
   withCredentials: true,
-  // 👇 추가
   xsrfCookieName: 'csrftoken',
   xsrfHeaderName: 'X-CSRFToken',
   headers: {
@@ -345,7 +381,7 @@ instatnceWithImg.interceptors.response.use(
           processQueue(null, null);
           return instatnceWithImg(originalRequest);
         } else {
-          const res = await instance.get('/api/v2/manager/auth/');
+          const res = await instanceV2.get('/api/v2/manager/auth/');
           const newAccessToken = res.data?.data?.access;
           if (!newAccessToken) throw new Error('토큰이 응답에 없습니다.');
 

--- a/vite.config.d.ts
+++ b/vite.config.d.ts
@@ -1,2 +1,2 @@
-declare const _default: import("vite").UserConfig;
+declare const _default: import("vite").UserConfigFnObject;
 export default _default;

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,24 +1,39 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 // https://vite.dev/config/
-export default defineConfig({
-    plugins: [react(), basicSsl()],
-    server: {
-        // https: true,
-        port: 5173,
-    },
-    resolve: {
-        alias: {
-            '@components': path.resolve(__dirname, 'src/components'),
-            '@pages': path.resolve(__dirname, 'src/pages'),
-            '@routes': path.resolve(__dirname, 'src/routes'),
-            '@styles': path.resolve(__dirname, 'src/styles'),
-            '@hooks': path.resolve(__dirname, 'src/hooks'),
-            '@constants': path.resolve(__dirname, 'src/constants'),
-            '@assets': path.resolve(__dirname, 'src/assets'),
-            '@services': path.resolve(__dirname, 'src/services'),
+export default defineConfig(({ mode }) => {
+    // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
+    const env = loadEnv(mode, process.cwd(), '');
+    const apiTarget = env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
+    return {
+        plugins: [react(), basicSsl()],
+        server: {
+            port: 5173,
+            proxy: {
+                // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
+                '/api/v3': {
+                    target: apiTarget,
+                    changeOrigin: true,
+                },
+                '/api/v2': {
+                    target: apiTarget,
+                    changeOrigin: true,
+                },
+            },
         },
-    },
+        resolve: {
+            alias: {
+                '@components': path.resolve(__dirname, 'src/components'),
+                '@pages': path.resolve(__dirname, 'src/pages'),
+                '@routes': path.resolve(__dirname, 'src/routes'),
+                '@styles': path.resolve(__dirname, 'src/styles'),
+                '@hooks': path.resolve(__dirname, 'src/hooks'),
+                '@constants': path.resolve(__dirname, 'src/constants'),
+                '@assets': path.resolve(__dirname, 'src/assets'),
+                '@services': path.resolve(__dirname, 'src/services'),
+            },
+        },
+    };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,28 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => {
+  // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiTarget = env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
+
+  return {
   plugins: [react(), basicSsl()],
   server: {
-    // https: true,
     port: 5173,
+    proxy: {
+      // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
+      '/api/v3': {
+        target: apiTarget,
+        changeOrigin: true,
+      },
+      '/api/v2': {
+        target: apiTarget,
+        changeOrigin: true,
+      },
+    },
   },
   resolve: {
     alias: {
@@ -21,4 +36,6 @@ export default defineConfig({
       '@services': path.resolve(__dirname, 'src/services'),
     },
   },
+  };
 });
+


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
Safari/iOS WebKit ITP가 SameSite=None 쿠키를 서드파티로 간주해 차단하는 문제 해결
백엔드의 SameSite=None → Lax 변경에 맞춰 FE 프록시 구조로 전환
V2 / V3 axios 인스턴스 분리
v2는 추후 삭제예정 

## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->
netlify.toml

배포 컨텍스트별 API 리다이렉트 추가
context.production → prod.dorder-api.shop
context.deploy-preview → dev.dorder-api.shop
브라우저가 /api/v3/* 요청을 same-origin으로 인식하게 되어 SameSite=Lax 쿠키 정상 전송
vite.config.ts

로컬 개발용 proxy 설정 추가 (/api/v3 → VITE_BASE_URL)
.env의 VITE_BASE_URL을 proxy target으로 사용해 환경별 분리
src/services/instance.ts

instance / instatnceWithImg baseURL VITE_BASE_URL → '/' (상대경로)
instanceV2 신규 추가 — 절대경로 baseURL, Bearer 토큰 인터셉터, v2 전환 완료 시 제거 예정
서비스 파일

v2 엔드포인트 호출부 instance → instanceV2 교체
UserService.ts — postSignup, login
CouponService.ts — getCouponDetail, getCouponDetailCodeList
useStaffCall.ts — staff-calls GET
dashboard.api.ts — statistic GET
LiveOrderServiceV2.ts — 전체 호출

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #14 
