### PR TITLE
🐛 [Fix] #14 -  Netlify 배포 환경 API redirect 404 오류 수정

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,32 +1,12 @@
-# ── 프로덕션 배포 (main 브랜치) ─────────────────────────────────────────────
-[context.production]
-[[context.production.redirects]]
+# ── API 프록시 redirect (SPA 규칙보다 반드시 위에 있어야 함) ─────────────────
+# force = true: 파일이 존재하더라도 강제로 redirect 적용
+[[redirects]]
   from = "/api/v3/*"
   to = "https://prod.dorder-api.shop/api/v3/:splat"
   status = 200
   force = true
 
-[[context.production.redirects]]
-  from = "/api/v2/*"
-  to = "https://prod.dorder-api.shop/api/v2/:splat"
-  status = 200
-  force = true
-
-# ── 브랜치/PR 미리보기 (develop 등) ─────────────────────────────────────────
-[context.deploy-preview]
-[[context.deploy-preview.redirects]]
-  from = "/api/v3/*"
-  to = "https://dev.dorder-api.shop/api/v3/:splat"
-  status = 200
-  force = true
-
-[[context.deploy-preview.redirects]]
-  from = "/api/v2/*"
-  to = "https://dev.dorder-api.shop/api/v2/:splat"
-  status = 200
-  force = true
-
-# ── SPA 라우팅 (공통) ────────────────────────────────────────────────────────
+# ── SPA 라우팅 (모든 경로를 index.html로) ────────────────────────────────────
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
netlify.toml context-specific redirect([context.production]) 방식에서 글로벌 [[redirects]] 방식으로 변경

context-specific redirect가 Netlify에서 의도대로 적용되지 않아 배포 환경에서 /api/v3/* 요청이 모두 404 발생하던 문제 수정

force = true 옵션으로 SPA 라우팅 규칙(/*)보다 API redirect가 먼저 매칭되도록 보장

## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->
로컬(vite proxy) / 배포(netlify.toml redirect) 환경이 완전히 분리되어 각각 독립적으로 동작
로컬: vite.config.ts proxy → .env의 dev.dorder-api.shop
배포: netlify.toml redirect → prod.dorder-api.shop
## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->
netlify.toml은 Netlify 서버에서만 동작, 로컬 개발에는 영향 없음
## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #14 
