### PR TITLE
🐛 [Fix] #14 - 첫 접속 시 CSRF 토큰 없어 로그인 400 오류 수정

### DIFF
--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -123,20 +123,30 @@ async function v3RefreshFallbackRetry(
 
 // 요청 인터셉터: 로그인/회원가입/refresh URL에는 Authorization 제외
 instance.interceptors.request.use(
-  (config: InternalAxiosRequestConfig) => {
+  async (config: InternalAxiosRequestConfig) => {
     const token = localStorage.getItem('accessToken');
     if (token && !isAuthEndpoint(config.url)) {
       config.headers['Authorization'] = `Bearer ${token}`;
     }
 
-    // 👇 핵심 해결 로직: POST, PATCH 등 안전하지 않은 메서드일 때 직접 쿠키에서 꺼내서 헤더에 강제 주입!
-    if (isUnsafeMethod(config.method)) {
-      const csrfCookie = document.cookie
+    // unsafe 메서드(POST/PATCH/PUT/DELETE)일 때 CSRF 토큰 주입
+    if (isUnsafeMethod(config.method) && !isCsrfTokenEndpoint(config.url)) {
+      let csrfToken = document.cookie
         .split('; ')
         .find((row) => row.startsWith('csrftoken='))
         ?.split('=')[1];
-      if (csrfCookie) {
-        config.headers['X-CSRFToken'] = csrfCookie;
+
+      // 쿠키에 없으면(첫 접속 등) 서버에서 미리 발급받아 주입 — instatnceWithImg와 동일
+      if (!csrfToken) {
+        try {
+          csrfToken = (await fetchCsrfToken()) ?? undefined;
+        } catch (e) {
+          console.error('CSRF 토큰 사전 발급 실패', e);
+        }
+      }
+
+      if (csrfToken) {
+        config.headers['X-CSRFToken'] = csrfToken;
       }
     }
 


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
배포 환경 첫 접속 시 csrftoken 쿠키가 없는 상태에서 login POST 요청 시 CSRF 헤더 누락으로 400 오류 발생하던 문제 수정
instance request interceptor에 CSRF 토큰 사전 발급 로직 추가
기존에 instatnceWithImg에만 적용되어 있던 "쿠키 없으면 서버에서 미리 fetch" 동작을 instance에도 동일하게 적용

## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->
instance / instatnceWithImg 두 인스턴스의 CSRF 처리 방식이 통일됨
쿠키 있으면 그대로 사용, 없으면 /api/v3/django/auth/csrf-token/ 사전 호출 후 주입
## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->
instance를 사용하는 모든 unsafe 메서드(POST/PATCH/PUT/DELETE) 요청에 적용됨
CSRF 토큰 endpoint 자기 자신 호출은 제외 처리되어 있어 무한 루프 없음
## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #14 
