### PR TITLE
🐛 [Fix] #15 - 로컬 쿠키 도메인 이슈 및 mypage API 직접 호출 수정

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,36 +4,39 @@ import path from 'path';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-    // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
-    const env = loadEnv(mode, process.cwd(), '');
-    const apiTarget = env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
-    return {
-        plugins: [react(), basicSsl()],
-        server: {
-            port: 5173,
-            proxy: {
-                // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
-                '/api/v3': {
-                    target: apiTarget,
-                    changeOrigin: true,
-                },
-                '/api/v2': {
-                    target: apiTarget,
-                    changeOrigin: true,
-                },
-            },
+  // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiTarget =
+    env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
+  return {
+    plugins: [react(), basicSsl()],
+    server: {
+      port: 5173,
+      proxy: {
+        // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
+        '/api/v3': {
+          target: apiTarget,
+          changeOrigin: true,
+          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
         },
-        resolve: {
-            alias: {
-                '@components': path.resolve(__dirname, 'src/components'),
-                '@pages': path.resolve(__dirname, 'src/pages'),
-                '@routes': path.resolve(__dirname, 'src/routes'),
-                '@styles': path.resolve(__dirname, 'src/styles'),
-                '@hooks': path.resolve(__dirname, 'src/hooks'),
-                '@constants': path.resolve(__dirname, 'src/constants'),
-                '@assets': path.resolve(__dirname, 'src/assets'),
-                '@services': path.resolve(__dirname, 'src/services'),
-            },
+        '/api/v2': {
+          target: apiTarget,
+          changeOrigin: true,
+          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
         },
-    };
+      },
+    },
+    resolve: {
+      alias: {
+        '@components': path.resolve(__dirname, 'src/components'),
+        '@pages': path.resolve(__dirname, 'src/pages'),
+        '@routes': path.resolve(__dirname, 'src/routes'),
+        '@styles': path.resolve(__dirname, 'src/styles'),
+        '@hooks': path.resolve(__dirname, 'src/hooks'),
+        '@constants': path.resolve(__dirname, 'src/constants'),
+        '@assets': path.resolve(__dirname, 'src/assets'),
+        '@services': path.resolve(__dirname, 'src/services'),
+      },
+    },
+  };
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,36 +6,41 @@ import basicSsl from '@vitejs/plugin-basic-ssl';
 export default defineConfig(({ mode }) => {
   // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
   const env = loadEnv(mode, process.cwd(), '');
-  const apiTarget = env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
+  const apiTarget =
+    env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
 
   return {
-  plugins: [react(), basicSsl()],
-  server: {
-    port: 5173,
-    proxy: {
-      // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
-      '/api/v3': {
-        target: apiTarget,
-        changeOrigin: true,
-      },
-      '/api/v2': {
-        target: apiTarget,
-        changeOrigin: true,
+    plugins: [react(), basicSsl()],
+    server: {
+      port: 5173,
+      proxy: {
+        // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
+        '/api/v3': {
+          target: apiTarget,
+          changeOrigin: true,
+          // 백엔드가 Set-Cookie: Domain=.dorder-api.shop으로 내려주는데
+          // localhost는 해당 도메인이 아니라 브라우저가 쿠키를 거부함.
+          // cookieDomainRewrite로 localhost가 쿠키를 수락하도록 도메인 재작성.
+          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+        },
+        '/api/v2': {
+          target: apiTarget,
+          changeOrigin: true,
+          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+        },
       },
     },
-  },
-  resolve: {
-    alias: {
-      '@components': path.resolve(__dirname, 'src/components'),
-      '@pages': path.resolve(__dirname, 'src/pages'),
-      '@routes': path.resolve(__dirname, 'src/routes'),
-      '@styles': path.resolve(__dirname, 'src/styles'),
-      '@hooks': path.resolve(__dirname, 'src/hooks'),
-      '@constants': path.resolve(__dirname, 'src/constants'),
-      '@assets': path.resolve(__dirname, 'src/assets'),
-      '@services': path.resolve(__dirname, 'src/services'),
+    resolve: {
+      alias: {
+        '@components': path.resolve(__dirname, 'src/components'),
+        '@pages': path.resolve(__dirname, 'src/pages'),
+        '@routes': path.resolve(__dirname, 'src/routes'),
+        '@styles': path.resolve(__dirname, 'src/styles'),
+        '@hooks': path.resolve(__dirname, 'src/hooks'),
+        '@constants': path.resolve(__dirname, 'src/constants'),
+        '@assets': path.resolve(__dirname, 'src/assets'),
+        '@services': path.resolve(__dirname, 'src/services'),
+      },
     },
-  },
   };
 });
-


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
- 백엔드 COOKIE_DOMAIN='.dorder-api.shop' 적용 이후 로컬 개발 환경에서 로그인 후 튕기는 문제 수정
- vite proxy에 cookieDomainRewrite 추가 — Set-Cookie: Domain=.dorder-api.shop → localhost로 재작성해 브라우저가 쿠키를 수락하도록 처리
- mypage 관련 API 파일 4개가 공용 instance 대신 VITE_BASE_URL로 자체 axios 인스턴스를 생성해 dev 서버로 직접 요청하던 문제 수정
- getManagers.ts, logout.ts, resetTableData.ts, getQRDownload.ts → 공용 instance로 교체


## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->
cookieDomainRewrite는 vite dev server에서만 동작하는 설정으로 빌드 결과물 및 Netlify 배포에는 영향 없음
mypage API들이 공용 instance(baseURL: /)를 사용해 Netlify 프록시를 정상적으로 경유하게 됨
## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- ex) #14 
