### PR TITLE
✨ [Fix] #14 - 로컬 WebSocket 인증 실패 및 쿠키 도메인 이슈 수정

### DIFF
--- a/src/components/header/hooks/useBoothRevenue.ts
+++ b/src/components/header/hooks/useBoothRevenue.ts
@@ -2,25 +2,12 @@
 
 import { useState, useEffect, useRef, useCallback } from 'react';
 import BoothService from '@services/BoothService';
+import { getWsUrl } from '@utils/getWsUrl';
 
-// 쿠키 기반 인증으로 전환되어 URL에 토큰을 포함하지 않음.
-// VITE_BASE_URL(http/https)을 ws/wss로 자동 변환하여 사용.
 const WS_PATH = '/ws/django/booth/sales/';
 
 function getSalesWsUrl(): string {
-  // VITE_WS_URL: WebSocket 전용 환경변수 (wss:// 또는 ws://)
-  // VITE_BASE_URL은 HTTP API용이므로 WS URL 생성에는 VITE_WS_URL 사용
-  const base = (import.meta.env.VITE_WS_URL ?? '')
-    .toString()
-    .replace(/\/+$/, '');
-  if (!base) return '';
-  if (base.startsWith('https://'))
-    return `${base.replace('https://', 'wss://')}${WS_PATH}`;
-  if (base.startsWith('http://'))
-    return `${base.replace('http://', 'ws://')}${WS_PATH}`;
-  if (base.startsWith('wss://') || base.startsWith('ws://'))
-    return `${base}${WS_PATH}`;
-  return '';
+  return getWsUrl(WS_PATH);
 }
 
 // close code 정의 (명세 기준)

--- a/src/pages/dashboard/_hooks/useStatisticsWS.ts
+++ b/src/pages/dashboard/_hooks/useStatisticsWS.ts
@@ -1,6 +1,7 @@
 // src/pages/Dashboard/_hooks/useStatisticsWSLite.ts
 import { useEffect, useRef } from "react";
 import type { DashboardData } from "../_services/dashboard.types";
+import { getWsUrl } from "@utils/getWsUrl";
 
 const TYPE_INIT = "INIT_STATISTICS";
 const TYPE_PATCH = "STATISTICS_UPDATED";
@@ -11,14 +12,6 @@ type PatchMsg = { type: typeof TYPE_PATCH; data: Partial<DashboardData> };
 type ErrMsg = { type: typeof TYPE_ERROR; code: number; message: string };
 type WsMsg = InitMsg | PatchMsg | ErrMsg | any;
 
-function toWebSocketOrigin(raw: string): string {
-  const b = raw.trim().replace(/\/+$/, "");
-  if (!b) return "";
-  if (b.startsWith("wss://") || b.startsWith("ws://")) return b;
-  if (b.startsWith("https://")) return b.replace("https://", "wss://");
-  if (b.startsWith("http://")) return b.replace("http://", "ws://");
-  return "";
-}
 
 export default function useStatisticsWSLite({
   onInit,
@@ -38,13 +31,11 @@ export default function useStatisticsWSLite({
       return;
     }
 
-    const base = toWebSocketOrigin(import.meta.env.VITE_WS_URL || "");
-    if (!base) {
-      console.error("[WS STAT] VITE_WS_URL 비어있거나 유효한 WS 오리진이 아님");
+    const url = getWsUrl(`/ws/statistics/?token=${encodeURIComponent(token)}`);
+    if (!url) {
+      console.error("[WS STAT] WS URL 생성 실패 (VITE_WS_URL 확인)");
       return;
     }
-
-    const url = `${base}/ws/statistics/?token=${encodeURIComponent(token)}`;
     const ws = new WebSocket(url);
     wsRef.current = ws;
 

--- a/src/pages/orderlistpage/utils/getOrderManagementWsUrl.ts
+++ b/src/pages/orderlistpage/utils/getOrderManagementWsUrl.ts
@@ -1,35 +1,7 @@
-/**
- * Order 관리 WebSocket URL 생성
- * Path: /ws/django/booth/orders/management/ (OpenAPI에 적힌 /api/.../booth/order/management/ 는 HTTP용일 수 있음)
- * - 쿠키 기반 인증 (브라우저 동일 조건에서 세션 쿠키 전송)
- * - VITE_BASE_URL 또는 VITE_WS_URL (https → wss 자동 변환)
- */
+import { getWsUrl } from '@utils/getWsUrl';
 
 const WS_PATH = '/ws/django/booth/orders/management/';
 
-/** http(s) 또는 이미 ws(s)인 베이스를 WebSocket 스킴으로 통일 */
-function toWebSocketOrigin(base: string): string {
-  const b = base.replace(/\/+$/, '');
-  if (!b) return '';
-  if (b.startsWith('wss://') || b.startsWith('ws://')) return b;
-  if (b.startsWith('https://')) return b.replace('https://', 'wss://');
-  if (b.startsWith('http://')) return b.replace('http://', 'ws://');
-  return '';
-}
-
-function getWsBaseUrl(): string {
-  const wsEnv = (import.meta.env.VITE_WS_URL ?? '').toString().trim();
-  if (wsEnv) {
-    const normalized = toWebSocketOrigin(wsEnv);
-    if (normalized) return normalized;
-  }
-
-  const httpBase = (import.meta.env.VITE_BASE_URL ?? '').toString().replace(/\/+$/, '');
-  return toWebSocketOrigin(httpBase);
-}
-
 export function getOrderManagementWsUrl(): string {
-  const base = getWsBaseUrl();
-  if (!base) return '';
-  return `${base}${WS_PATH}`;
+  return getWsUrl(WS_PATH);
 }

--- a/src/pages/tableView/_ws/useTableDetailWS.ts
+++ b/src/pages/tableView/_ws/useTableDetailWS.ts
@@ -1,17 +1,14 @@
 // tableView/_ws/useTableDetailWS.ts
 import { useEffect, useRef } from "react";
 import { TableWSPayload } from "./types";
+import { getWsUrl } from "@utils/getWsUrl";
 
 interface UseTableDetailWSOptions {
     tableNum: number;
     onConnectionEstablished?: (data: any) => void;
     // 상세뷰에서 필요한 추가 이벤트(예: order_update) 콜백 등록
-    onOrderUpdate?: (data: any) => void; 
+    onOrderUpdate?: (data: any) => void;
 }
-
-const WS_BASE_URL = (import.meta.env.VITE_BASE_URL || "")
-    .replace(/^http/, "ws")
-    .replace(/\/$/, "");
 
 export const useTableDetailWS = ({ tableNum, ...options }: UseTableDetailWSOptions) => {
     const wsRef = useRef<WebSocket | null>(null);
@@ -21,7 +18,7 @@ export const useTableDetailWS = ({ tableNum, ...options }: UseTableDetailWSOptio
 
         let isMounted = true;
         
-        const wsUrl = `${WS_BASE_URL}/ws/django/tables/${tableNum}/`;
+        const wsUrl = getWsUrl(`/ws/django/tables/${tableNum}/`);
         const socket = new WebSocket(wsUrl);
         wsRef.current = socket;
 

--- a/src/pages/tableView/_ws/useTablesWS.ts
+++ b/src/pages/tableView/_ws/useTablesWS.ts
@@ -1,6 +1,7 @@
 // tableView/_ws/useTablesWS.ts
 import { useEffect, useRef } from "react";
 import { TableWSPayload } from "./types";
+import { getWsUrl } from "@utils/getWsUrl";
 
 interface UseTablesWSOptions {
     onConnectionEstablished?: (data: any) => void;
@@ -11,10 +12,6 @@ interface UseTablesWSOptions {
     onError?: (data: any) => void;
 }
 
-const WS_BASE_URL = (import.meta.env.VITE_BASE_URL || "")
-  .replace(/^http/, "ws") // http(s)를 ws(s)로 변환
-  .replace(/\/$/, "");    // 맨 뒤 슬래시 제거
-
 export const useTablesWS = (options: UseTablesWSOptions = {}) => {
     const wsRef = useRef<WebSocket | null>(null);
     const reconnectTimeoutRef = useRef<number | null>(null);
@@ -23,12 +20,7 @@ export const useTablesWS = (options: UseTablesWSOptions = {}) => {
         let isMounted = true;
 
         const connect = () => {
-            // 1. 토큰 가져오기 (CORS 환경에서 쿠키가 전송되지 않을 때를 대비한 쿼리스트링 방식)
-            const token = localStorage.getItem('accessToken') || "";
-            
-            // 2. URL 설정 (토큰 포함)
-            // 🚨 만약 이 주소로도 안 되면, 중간에 v3를 넣어서 테스트 해보세요! (/ws/v3/django/...)
-            const wsUrl = `${WS_BASE_URL}/ws/django/booth/tables/?token=${token}`;
+            const wsUrl = getWsUrl('/ws/django/booth/tables/');
             
             console.log(`[WS:Tables] 🔄 연결 시도 중... URL: ${wsUrl}`);
 

--- a/src/utils/getWsUrl.ts
+++ b/src/utils/getWsUrl.ts
@@ -1,0 +1,23 @@
+/**
+ * WebSocket URL 생성 유틸
+ *
+ * 로컬 개발 환경 문제:
+ *   - vite cookieDomainRewrite로 인해 쿠키가 localhost 도메인으로 저장됨
+ *   - WS가 wss://dev.dorder-api.shop 으로 직접 연결하면 localhost 쿠키를 안 보냄 → 인증 실패
+ *   - 해결: 로컬에서는 wss://localhost:port 로 연결 → vite proxy(/ws)가 백엔드로 포워딩
+ *           → proxy가 localhost 쿠키를 그대로 백엔드에 전달 → 인증 성공
+ *
+ * 프로덕션:
+ *   - VITE_WS_URL(wss://prod.dorder-api.shop) 로 직접 연결
+ *   - 쿠키 Domain=.dorder-api.shop → admin.dorder-api.shop과 같은 도메인 → 정상 전달
+ */
+export function getWsUrl(path: string): string {
+  if (import.meta.env.DEV) {
+    // 로컬: vite proxy 경유 (wss://localhost:5173/ws/...)
+    const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${window.location.host}${path}`;
+  }
+  // 프로덕션: VITE_WS_URL 직접 사용
+  const base = (import.meta.env.VITE_WS_URL ?? '').toString().replace(/\/+$/, '');
+  return base ? `${base}${path}` : '';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
       "@hooks/*": ["src/hooks/*"],
       "@constants/*": ["src/constants/*"],
       "@assets/*": ["src/assets/*"],
-      "@services/*": ["src/services/*"]
+      "@services/*": ["src/services/*"],
+      "@utils/*": ["src/utils/*"]
     },
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "target": "ES2020",

--- a/vite.config.js
+++ b/vite.config.js
@@ -24,6 +24,12 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
         },
+        '/ws': {
+          target: apiTarget,
+          changeOrigin: true,
+          ws: true,
+          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+        },
       },
     },
     resolve: {
@@ -36,6 +42,7 @@ export default defineConfig(({ mode }) => {
         '@constants': path.resolve(__dirname, 'src/constants'),
         '@assets': path.resolve(__dirname, 'src/assets'),
         '@services': path.resolve(__dirname, 'src/services'),
+        '@utils': path.resolve(__dirname, 'src/utils'),
       },
     },
   };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -28,6 +28,14 @@ export default defineConfig(({ mode }) => {
           changeOrigin: true,
           cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
         },
+        // WebSocket proxy: wss://localhost:5173/ws/... → wss://dev.dorder-api.shop/ws/...
+        // localhost 쿠키를 백엔드에 그대로 전달하기 위해 vite proxy 경유 필수
+        '/ws': {
+          target: apiTarget,
+          changeOrigin: true,
+          ws: true,
+          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+        },
       },
     },
     resolve: {
@@ -40,6 +48,7 @@ export default defineConfig(({ mode }) => {
         '@constants': path.resolve(__dirname, 'src/constants'),
         '@assets': path.resolve(__dirname, 'src/assets'),
         '@services': path.resolve(__dirname, 'src/services'),
+      '@utils': path.resolve(__dirname, 'src/utils'),
       },
     },
   };


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
백엔드 COOKIE_DOMAIN='.dorder-api.shop' 적용 이후 로컬 개발 환경에서 WebSocket 인증 실패하던 문제 수정
cookieDomainRewrite로 localhost에 저장된 쿠키가 wss://dev.dorder-api.shop으로 직접 연결하는 WebSocket에는 전달되지 않는 구조적 문제 해결
vite proxy에 /ws 경로 추가 — 로컬 WS 연결을 wss://localhost:5173/ws/... 경유로 변경해 proxy가 쿠키를 백엔드에 전달
WebSocket URL 생성 공통 유틸 getWsUrl.ts 추가 — 환경별(로컬/배포) URL 분기 일원화
모든 WebSocket 훅에서 VITE_BASE_URL 직접 사용 제거, getWsUrl 유틸로 통일


## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->
로컬 / 배포 환경별 WS URL 분기 로직을 getWsUrl.ts 한 곳에서 관리
## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->
vite.config.js / vite.config.ts 둘 다 수정 필요 (vite가 .js를 우선 로드하는 이슈로 두 파일이 항상 동기화되어야 함)
tsconfig.json에 @utils path alias 추가됨 — 신규 유틸 파일은 src/utils/ 하위에 위치
## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #14
