### PR TITLE
[♻️ Refactor] #46 - 로그인 실패 시 리로드 방지 및 로그인 UI 오류 표시

### DIFF
--- a/src/pages/login/LoginPage.styled.ts
+++ b/src/pages/login/LoginPage.styled.ts
@@ -82,6 +82,14 @@ export const Cover = styled.div`
   width: 100%;
 `;
 
+export const ErrorMessage = styled.p`
+  ${({ theme }) => theme.fonts.Medium14};
+  color: ${({ theme }) => theme.colors.Error};
+  margin: 0;
+  width: 100%;
+  box-sizing: border-box;
+`;
+
 export const BackIMG = styled.img`
   position: absolute;
   left: 40px;

--- a/src/pages/login/LoginPage.tsx
+++ b/src/pages/login/LoginPage.tsx
@@ -17,14 +17,18 @@ export type LoginPageProps = {
   mockLogin?: 'success' | 'error';
 };
 
+const DEFAULT_LOGIN_ERROR = '아이디 혹은 비밀번호가 일치하지 않아요.';
+
 const LoginPage = ({ mockLogin }: LoginPageProps = {}) => {
   const navigate = useNavigate();
   const [formData, setFormData] = useState({
     username: '',
     password: '',
   });
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   const handleLogin = async () => {
+    setLoginError(null);
     try {
       let response: {
         message?: string;
@@ -46,19 +50,21 @@ const LoginPage = ({ mockLogin }: LoginPageProps = {}) => {
         response = await UserService.loginV3(formData);
       }
 
-      const data = response.data ?? (response as { username?: string; booth_id?: number });
+      const data =
+        response.data ?? (response as { username?: string; booth_id?: number });
       const username = data.username ?? '';
       const booth_id = data.booth_id ?? 0;
 
       if (!username && booth_id === 0) {
-        alert('로그인 응답이 올바르지 않습니다.');
+        setLoginError('로그인 응답이 올바르지 않습니다.');
         return;
       }
 
       localStorage.setItem('Booth-ID', String(booth_id));
       navigate(ROUTE_PATHS.HOME);
     } catch (err) {
-      alert('로그인 실패했습니다. 다시 시도해 주세요.');
+      const msg = DEFAULT_LOGIN_ERROR;
+      setLoginError(msg);
     }
   };
 
@@ -76,18 +82,23 @@ const LoginPage = ({ mockLogin }: LoginPageProps = {}) => {
         <CommonInput
           label="아이디"
           placeholder="아이디를 입력하세요"
-          onValueSubmit={(val) =>
-            setFormData((prev) => ({ ...prev, username: val }))
-          }
+          onValueSubmit={(val) => {
+            setLoginError(null);
+            setFormData((prev) => ({ ...prev, username: val }));
+          }}
         />
         <CommonInput
           label="비밀번호"
           type="password"
           placeholder="비밀번호를 입력하세요"
-          onValueSubmit={(val) =>
-            setFormData((prev) => ({ ...prev, password: val }))
-          }
+          onValueSubmit={(val) => {
+            setLoginError(null);
+            setFormData((prev) => ({ ...prev, password: val }));
+          }}
         />
+        {loginError ? (
+          <S.ErrorMessage role="alert">{loginError}</S.ErrorMessage>
+        ) : null}
         <S.Cover>
           <NextButton
             onClick={handleLogin}

--- a/src/pages/mypage/MyPage.tsx
+++ b/src/pages/mypage/MyPage.tsx
@@ -9,6 +9,7 @@ import { getManagerInfo } from './apis/getManagers';
 import { patchManagerInfo, type BoothMyPageData } from './apis/getManagerPatch';
 import { downloadManagerQR } from './apis/getQRDownload';
 import { requestLogout } from './apis/logout';
+import { redirectToLoginPage } from '@utils/redirectToLoginPage';
 import { resetTableData } from './apis/resetTableData';
 import { LoadingSpinner } from '../menu/api/LoadingSpinner';
 
@@ -165,10 +166,10 @@ const MyPage = () => {
       await requestLogout();
       localStorage.removeItem('accessToken'); 
       toast.success('로그아웃되었습니다.', { closeButton: false, style: toToastStyle() });
-      window.location.href = '/login';
+      redirectToLoginPage();
     } catch (err: any) {
       toast.error(err?.message || '로그아웃에 실패했습니다.', { closeButton: false, style: toToastStyle() });
-      window.location.href = '/login';
+      redirectToLoginPage();
     } finally { setShowLogoutModal(false); }
   };
 

--- a/src/pages/orderlistpage/hooks/useOrderManagementWebSocket.ts
+++ b/src/pages/orderlistpage/hooks/useOrderManagementWebSocket.ts
@@ -16,6 +16,7 @@ import {
   getOrderWsErrorInfo,
 } from '../types/orderManagementWs';
 import UserService from '@services/UserService';
+import { redirectToLoginPage } from '@utils/redirectToLoginPage';
 
 const AUTH_FAILURE_CLOSE_CODE = 4001;
 /** JWT/세션 없음 (Django AdminOrderManagementConsumer._authenticate) */
@@ -80,7 +81,7 @@ export function useOrderManagementWebSocket(
               codeStr === '401' ||
               errInfo.code === 401
             ) {
-              window.location.href = '/login';
+              redirectToLoginPage();
             }
             return;
           }
@@ -134,7 +135,7 @@ export function useOrderManagementWebSocket(
         if (aborted) return;
 
         if (e.code === AUTH_FAILURE_CLOSE_CODE) {
-          window.location.href = '/login';
+          redirectToLoginPage();
           return;
         }
         if (e.code === NO_BOOTH_CLOSE_CODE) {

--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -5,6 +5,7 @@ import axios, {
   InternalAxiosRequestConfig,
 } from 'axios';
 import UserService from './UserService';
+import { redirectToLoginPage } from '@utils/redirectToLoginPage';
 
 // V3 인스턴스: 상대경로 baseURL → vite proxy(로컬) / netlify redirect(배포) 경유
 export const instance: AxiosInstance = axios.create({
@@ -47,6 +48,18 @@ const isAuthEndpoint = (url?: string) =>
 const isCsrfTokenEndpoint = (url?: string) =>
   url?.includes('/api/v3/django/auth/csrf-token/');
 
+/**
+ * 로그인·회원가입 등 아직 로그인되지 않은 상태의 auth 요청.
+ * 이 경로에서 오는 401은 "비밀번호 틀림" 등이므로 refresh/location.href 로그인 이동을 하면 안 됨.
+ */
+const isV3UnauthenticatedAuthRequest = (url?: string): boolean => {
+  if (!url?.includes('/api/v3/django/auth/')) return false;
+  if (url.includes('/refresh/')) return false;
+  if (url.includes('/csrf-token')) return false;
+  const path = url.split('?')[0].replace(/\/+$/, '');
+  return path.endsWith('/django/auth') || path.endsWith('/signup');
+};
+
 const isUnsafeMethod = (method?: string) => {
   const m = (method || 'GET').toUpperCase();
   return !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(m);
@@ -77,7 +90,7 @@ instanceV2.interceptors.response.use(
   (error: AxiosError) => {
     if (error.response?.status === 401) {
       localStorage.removeItem('accessToken');
-      window.location.href = '/login';
+      redirectToLoginPage();
     }
     return Promise.reject(error);
   }
@@ -144,7 +157,7 @@ const clearTokens = () => {
 };
 
 const redirectToLogin = () => {
-  window.location.href = '/login';
+  redirectToLoginPage();
 };
 
 function shouldAttemptV3RefreshRetry(originalRequest: any): boolean {
@@ -204,6 +217,13 @@ const v3ResponseErrorInterceptor = async (error: AxiosError, client: AxiosInstan
     return Promise.reject(
       new Error('세션/토큰이 만료되었습니다. 다시 로그인해주세요.')
     );
+  }
+
+  if (
+    error.response?.status === 401 &&
+    isV3UnauthenticatedAuthRequest(originalRequest.url)
+  ) {
+    return Promise.reject(error);
   }
 
   if (error.response?.status === 401 && !originalRequest._retry) {

--- a/src/utils/redirectToLoginPage.ts
+++ b/src/utils/redirectToLoginPage.ts
@@ -1,0 +1,14 @@
+import { ROUTE_PATHS } from '@constants/routeConstants';
+
+/**
+ * 로그인 페이지로 이동. 이미 `/login`에 있으면 리로드/이동하지 않음.
+ */
+export function redirectToLoginPage(): void {
+  const raw = window.location.pathname || '/';
+  const path = raw.replace(/\/+$/, '') || '/';
+  const login = ROUTE_PATHS.LOGIN;
+  if (path === login || path.endsWith(login)) {
+    return;
+  }
+  window.location.href = login;
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -4,46 +4,50 @@ import path from 'path';
 import basicSsl from '@vitejs/plugin-basic-ssl';
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
-  // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
-  const env = loadEnv(mode, process.cwd(), '');
-  const apiTarget =
-    env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
-  return {
-    plugins: [react(), basicSsl()],
-    server: {
-      port: 5173,
-      proxy: {
-        // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
-        '/api/v3': {
-          target: apiTarget,
-          changeOrigin: true,
-          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+    // .env에서 VITE_BASE_URL을 읽어 로컬 개발용 proxy target으로 사용
+    const env = loadEnv(mode, process.cwd(), '');
+    const apiTarget = env.VITE_BASE_URL?.replace(/\/+$/, '') || 'https://dev.dorder-api.shop';
+    return {
+        plugins: [react(), basicSsl()],
+        server: {
+            port: 5173,
+            proxy: {
+                // 로컬에서 /api/v3/* 요청을 .env의 VITE_BASE_URL로 포워딩
+                '/api/v3': {
+                    target: apiTarget,
+                    changeOrigin: true,
+                    // 백엔드가 Set-Cookie: Domain=.dorder-api.shop으로 내려주는데
+                    // localhost는 해당 도메인이 아니라 브라우저가 쿠키를 거부함.
+                    // cookieDomainRewrite로 localhost가 쿠키를 수락하도록 도메인 재작성.
+                    cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+                },
+                '/api/v2': {
+                    target: apiTarget,
+                    changeOrigin: true,
+                    cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+                },
+                // WebSocket proxy: wss://localhost:5173/ws/... → wss://dev.dorder-api.shop/ws/...
+                // localhost 쿠키를 백엔드에 그대로 전달하기 위해 vite proxy 경유 필수
+                '/ws': {
+                    target: apiTarget,
+                    changeOrigin: true,
+                    ws: true,
+                    cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+                },
+            },
         },
-        '/api/v2': {
-          target: apiTarget,
-          changeOrigin: true,
-          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
+        resolve: {
+            alias: {
+                '@components': path.resolve(__dirname, 'src/components'),
+                '@pages': path.resolve(__dirname, 'src/pages'),
+                '@routes': path.resolve(__dirname, 'src/routes'),
+                '@styles': path.resolve(__dirname, 'src/styles'),
+                '@hooks': path.resolve(__dirname, 'src/hooks'),
+                '@constants': path.resolve(__dirname, 'src/constants'),
+                '@assets': path.resolve(__dirname, 'src/assets'),
+                '@services': path.resolve(__dirname, 'src/services'),
+                '@utils': path.resolve(__dirname, 'src/utils'),
+            },
         },
-        '/ws': {
-          target: apiTarget,
-          changeOrigin: true,
-          ws: true,
-          cookieDomainRewrite: { '.dorder-api.shop': 'localhost' },
-        },
-      },
-    },
-    resolve: {
-      alias: {
-        '@components': path.resolve(__dirname, 'src/components'),
-        '@pages': path.resolve(__dirname, 'src/pages'),
-        '@routes': path.resolve(__dirname, 'src/routes'),
-        '@styles': path.resolve(__dirname, 'src/styles'),
-        '@hooks': path.resolve(__dirname, 'src/hooks'),
-        '@constants': path.resolve(__dirname, 'src/constants'),
-        '@assets': path.resolve(__dirname, 'src/assets'),
-        '@services': path.resolve(__dirname, 'src/services'),
-        '@utils': path.resolve(__dirname, 'src/utils'),
-      },
-    },
-  };
+    };
 });


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

- LoginPage: alert 제거 → 로그인 실패·응답 오류 시 **빨간 ErrorMessage**로 안내 (theme.colors.Error).
- Axios (instance): 잘못된 비밀번호 등으로 POST /api/v3/django/auth/·signup이 401일 때는 refresh / window.location 로그인 이동을 타지 않음 → 로그인 화면에서 불필요한 풀 리로드 방지.
- redirectToLoginPage 유틸: pathname이 이미 /login(또는 …/login)이면 location.href 생략.
- MyPage 로그아웃, 주문 관리 WebSocket 인증 실패 시에도 위 유틸로 동일 동작.
- vite.config.js: 설정 정리(포맷/구조).

## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->

- 로그인 실패가 401로 떨어질 때 전역 401 인터셉터가 refresh → 실패 → /login 강제 이동하던 흐름을 끊어, 같은 페이지에서 에러만 보이도록 한 점.
- redirectToLoginPage 한 곳에서 “이미 로그인 페이지면 이동 안 함”을 보장해, 향후 /login 리다이렉트 추가 시에도 중복 리로드를 줄임.

## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->

- **redirectToLoginPage()**를 쓰는 곳: instance/instanceV2 인증 실패 처리, MyPage 로그아웃, 주문 관리 WS 인증 오류.
- 앱이 basename 또는 /admin 등 프리픽스만 쓰는 경우, redirectToLoginPage의 pathname 판별이 의도와 다르면 그때 경로 규칙만 조정하면 됨.

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

#46
