### PR TITLE
🐛 [Fix] #62 -  세트메뉴 모달 수정, 헤더 웹소켓 연결

### DIFF
--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -3,26 +3,26 @@ import { useState } from 'react';
 
 import { IMAGE_CONSTANTS } from '@constants/imageConstants';
 import Bell from './_components/Bell';
-import LiveNotice from './_components/LiveNotice';
+// import LiveNotice from './_components/LiveNotice';
 
 import useBoothRevenue from './hooks/useBoothRevenue';
 import useAnimatedNumber from './hooks/useAnimatedNumber';
-import { useStaffCall } from './hooks/useStaffCall';
+// import { useStaffCall } from './hooks/useStaffCall';
 const Header = () => {
   const [isReloading, setIsReloading] = useState(false);
   const [modalOpen, setModalOpen] = useState(false);
 
   const { boothName, totalRevenues } = useBoothRevenue();
-  const { liveNotice, showLiveNotice, hasUnread, markAsRead } =
-    useStaffCall();
+  // const { liveNotice, showLiveNotice, hasUnread, markAsRead, notifications, activeCount } =
+  //   useStaffCall();
 
   const animatedRevenues = useAnimatedNumber(totalRevenues);
 
   const handleBellClick = () => {
     setModalOpen((prev) => !prev);
-    if (!modalOpen) {
-      markAsRead();
-    }
+    // if (!modalOpen) {
+    //   markAsRead();
+    // }
   };
 
   const handleReload = () => {
@@ -39,16 +39,18 @@ const Header = () => {
     <S.HeaderWrapper>
       <S.BoothName>{boothName || '부스 이름'}</S.BoothName>
 
-      {liveNotice && <LiveNotice message={liveNotice} show={showLiveNotice} />}
+      {/* <LiveNotice message={liveNotice ?? ''} show={showLiveNotice} /> */}
       <S.SalesInfoWrapper>
         <S.SalesInfoText>💰 총 매출</S.SalesInfoText>
         <S.TotalSales>{`${formatCurrency(animatedRevenues)}원`}</S.TotalSales>
 
         <Bell
-          active={hasUnread}
+          active={false}
           onClick={handleBellClick}
           modalOpen={modalOpen}
           onCloseModal={() => setModalOpen(false)}
+          notifications={[]}
+          activeCount={0}
         />
 
         <S.ReloadButton onClick={handleReload} disabled={isReloading}>

--- a/src/components/header/_components/Bell.tsx
+++ b/src/components/header/_components/Bell.tsx
@@ -1,29 +1,23 @@
 import styled from 'styled-components';
 import { IMAGE_CONSTANTS } from '@constants/imageConstants';
 import BellModal from './BellModal';
-import { dummyNotifications } from '../dummy/dummyNotifications';
+import { Notification } from '../dummy/dummyNotifications';
 
 interface BellProps {
-  active: boolean; // 배지 노출 여부 (hasUnread)
+  active: boolean;
   onClick: () => void;
   modalOpen: boolean;
   onCloseModal: () => void;
+  notifications: Notification[];
+  activeCount: number;
 }
-//actice나중에 추가 - API 연결 후 hasUnread 기반으로 active 재연결 필요
-const Bell = ({ onClick, modalOpen, onCloseModal }: BellProps) => {
-  // 미처리 알림 수 (더미 데이터 기반 — API 연결 시 교체)
-  const activeCount = dummyNotifications.filter((n) => !n.isProcessed).length;
 
-  // 아웃사이드 클릭 감지 제거 — 오버레이(Overlay)가 전체 화면을 덮어
-  // 클릭 아웃사이드를 처리하므로 중복 처리 불필요.
-  // 모달 내부 클릭 시 닫힘 현상도 이 리스너가 원인이었음.
-
+const Bell = ({ onClick, modalOpen, onCloseModal, notifications, activeCount }: BellProps) => {
   return (
     <BellWrapper onClick={onClick}>
       <img src={IMAGE_CONSTANTS.BELL} alt='알림 종 아이콘' />
-      {/* 미처리 알림 있을 때 숫자 배지 표시 (더미 데이터 기반 — API 연결 시 active 조건 재연결) */}
       {activeCount > 0 && <Badge>{activeCount}</Badge>}
-      <BellModal $active={modalOpen} onClose={onCloseModal} />
+      <BellModal $active={modalOpen} onClose={onCloseModal} notifications={notifications} />
     </BellWrapper>
   );
 };

--- a/src/components/header/_components/BellModal.tsx
+++ b/src/components/header/_components/BellModal.tsx
@@ -1,14 +1,14 @@
 import * as S from './BellModal.styled';
 import { createPortal } from 'react-dom';
-import { dummyNotifications } from '../dummy/dummyNotifications';
+import { Notification } from '../dummy/dummyNotifications';
 import { IMAGE_CONSTANTS } from '@constants/imageConstants';
 
 interface BellModalProps {
   $active: boolean;
   onClose: () => void;
+  notifications: Notification[];
 }
 
-// 시간 차이를 "X분 전" 형태로 변환
 const getTimeAgo = (date: Date): string => {
   const diff = Math.floor((Date.now() - date.getTime()) / 1000);
   if (diff < 60) return `${diff}초 전`;
@@ -19,24 +19,21 @@ const getTimeAgo = (date: Date): string => {
 };
 
 // 정렬: 미처리(오래된 순) → 처리중
-const getSortedNotifications = () =>
-  [...dummyNotifications].sort((a, b) => {
+const getSorted = (list: Notification[]) =>
+  [...list].sort((a, b) => {
     if (a.isProcessed !== b.isProcessed) return a.isProcessed ? 1 : -1;
     if (!a.isProcessed && !b.isProcessed)
       return a.createdAt.getTime() - b.createdAt.getTime();
     return 0;
   });
 
-const BellModal = ({ $active, onClose }: BellModalProps) => {
-  const sorted = getSortedNotifications();
+const BellModal = ({ $active, onClose, notifications }: BellModalProps) => {
+  const sorted = getSorted(notifications);
 
   return createPortal(
     <>
       <S.Overlay $active={$active} onClick={(e) => { e.stopPropagation(); onClose(); }} />
-      <S.BellModalWrapper
-        $active={$active}
-        onClick={(e) => e.stopPropagation()}
-      >
+      <S.BellModalWrapper $active={$active} onClick={(e) => e.stopPropagation()}>
         <S.ModalHeader>
           <S.ModalTitle>테이블 요청 현황</S.ModalTitle>
           <S.CloseButton onClick={onClose}>

--- a/src/components/header/hooks/useStaffCall.ts
+++ b/src/components/header/hooks/useStaffCall.ts
@@ -1,108 +1,116 @@
-import { useState, useEffect } from "react";
-import { AxiosError } from "axios";
-import { instanceV2 } from "@services/instance";
+import { useState, useEffect, useRef } from "react";
+import { getWsUrl } from "@utils/getWsUrl";
 import { BellPlayer } from "../BellPlayer";
+import { Notification, NotificationType } from "../dummy/dummyNotifications";
+import { useAuthStore } from "../../../stores/authStore";
 
-interface Notification {
+interface StaffCallWsItem {
   id: number;
-  message: string;
-  time: string;
+  call_type: string;
+  table_num?: number;
+  table_id?: number;
+  created_at?: string;
+  status?: string;
 }
 
-interface ApiCallStaff {
-  tableNumber: number;
-  createdAt: string;
+interface StaffCallWsMessage {
+  type: string;
+  data?: StaffCallWsItem[];
 }
+
+const mapCallType = (callType: string): NotificationType => {
+  if ((callType ?? "").toUpperCase() === "PAYMENT_CONFIRM") return "송금 확인 요청";
+  return "직원 호출";
+};
+
+const mapToNotification = (item: StaffCallWsItem): Notification => {
+  const s = (item.status ?? "").toUpperCase();
+  return {
+    id: item.id,
+    tableNumber: `T ${item.table_num ?? item.table_id ?? "?"}`,
+    type: mapCallType(item.call_type),
+    createdAt: item.created_at ? new Date(item.created_at) : new Date(),
+    isProcessed: s === "ACCEPTED" || s === "COMPLETED",
+  };
+};
 
 export const useStaffCall = () => {
+  const { booth_id: storeBoothId } = useAuthStore();
+  const localBoothId = Number(localStorage.getItem("Booth-ID") || "0") || null;
+  const booth_id = storeBoothId ?? localBoothId;
+
+  const [notifications, setNotifications] = useState<Notification[]>([]);
   const [liveNotice, setLiveNotice] = useState<string | null>(null);
   const [showLiveNotice, setShowLiveNotice] = useState(false);
-  const [notifications, setNotifications] = useState<Notification[]>([]);
   const [hasUnread, setHasUnread] = useState(false);
+  const knownIdsRef = useRef<Set<number>>(new Set());
 
   useEffect(() => {
-    BellPlayer.ensureUnlocked();
-
-    const fetchInitialNotifications = async () => {
-      try {
-        const response = await instanceV2.get<{
-          status: string;
-          data: ApiCallStaff[];
-        }>("/api/v2/booth/staff-calls/");
-
-        const fetchedNotifications: Notification[] = response.data.data.map(
-          (item) => ({
-            id: new Date(item.createdAt).getTime(),
-            message: `${item.tableNumber}번 테이블에서 직원을 호출했습니다.`,
-            time: new Date(item.createdAt).toLocaleTimeString("ko-KR"),
-          })
-        );
-
-        setNotifications(fetchedNotifications.slice(0, 7));
-      } catch (e) {
-        const error = e as AxiosError;
-        console.error("🔴 [GET] 초기 알림 기록 로딩 중 오류:", error.message);
-      }
-    };
-
-    fetchInitialNotifications();
-  }, []);
-
-  useEffect(() => {
-    const accessToken = localStorage.getItem("accessToken");
-    if (!accessToken) {
-      console.error("🔴 [CALL] 웹소켓 연결 실패: 액세스 토큰이 없습니다.");
+    console.log("[StaffCall WS] booth_id:", booth_id);
+    if (!booth_id) {
+      console.warn("[StaffCall WS] booth_id 없음 → 연결 안함");
       return;
     }
 
-    const wsUrl = `wss://api.test-d-order.store/ws/call/?token=${accessToken}`;
-    const ws = new WebSocket(wsUrl);
+    BellPlayer.ensureUnlocked();
 
-    // ws.onopen = () => console.log("✅ [CALL] 직원 호출 웹소켓 연결 성공!");
+    const url = getWsUrl(`/ws/server/staffcall`);
+    console.log("[StaffCall WS] 연결 시도:", url);
+
+    const ws = new WebSocket(url);
+
+    ws.onopen = () => {
+      console.log("[StaffCall WS] 연결 성공 ✅");
+      const payload = { type: "LIST", limit: 50, offset: 0 };
+      console.log("[StaffCall WS] LIST 요청 전송:", payload);
+      ws.send(JSON.stringify(payload));
+    };
 
     ws.onmessage = (event) => {
+      console.log("[StaffCall WS] 메시지 수신 (raw):", event.data);
       try {
-        const message = JSON.parse(event.data);
-        if (message.type === "CALL_STAFF") {
-          const noticeMessage = message.message;
+        const msg: StaffCallWsMessage = JSON.parse(event.data);
+        console.log("[StaffCall WS] 파싱된 메시지:", msg);
 
-          BellPlayer.play();
+        if (msg.type === "LIST_RESULT" || msg.type === "STAFF_CALL_SNAPSHOT") {
+          const mapped = (msg.data ?? []).map(mapToNotification);
+          console.log("[StaffCall WS] 매핑된 notifications:", mapped);
 
-          setLiveNotice(noticeMessage);
-          setShowLiveNotice(true);
-          setTimeout(() => setShowLiveNotice(false), 4000);
+          const newPending = mapped.filter(
+            (n) => !n.isProcessed && !knownIdsRef.current.has(n.id)
+          );
+          console.log("[StaffCall WS] 신규 미처리 항목:", newPending);
+          mapped.forEach((n) => knownIdsRef.current.add(n.id));
 
-          const newNotification: Notification = {
-            id: Date.now(),
-            message: noticeMessage,
-            time: new Date().toLocaleTimeString("ko-KR"),
-          };
+          if (newPending.length > 0) {
+            BellPlayer.play();
+            const first = newPending[0];
+            setLiveNotice(`${first.tableNumber} ${first.type}`);
+            setShowLiveNotice(true);
+            setTimeout(() => setShowLiveNotice(false), 4000);
+            setHasUnread(true);
+          }
 
-          setNotifications((prev) => [newNotification, ...prev].slice(0, 10));
-          setHasUnread(true);
+          setNotifications(mapped);
+        } else {
+          console.warn("[StaffCall WS] 미처리 메시지 타입:", msg.type);
         }
-      } catch (error) {
-        console.error("🔴 [CALL] 메시지 처리 중 오류 발생:", error);
+      } catch (err) {
+        console.error("[StaffCall WS] 메시지 파싱 오류:", err);
       }
     };
 
-    ws.onerror = (error) => console.error("🔴 [CALL] 웹소켓 에러 발생:", error);
-    // ws.onclose = () => console.log("⚪️ [CALL] 웹소켓 연결이 종료되었습니다.");
+    ws.onerror = (e) => console.error("[StaffCall WS] 에러 ❌:", e);
+    ws.onclose = (e) => console.log("[StaffCall WS] 연결 종료:", e.code, e.reason);
 
     return () => {
+      console.log("[StaffCall WS] cleanup → ws.close()");
       ws.close();
     };
-  }, []);
+  }, [booth_id]);
 
-  const markAsRead = () => {
-    setHasUnread(false);
-  };
+  const markAsRead = () => setHasUnread(false);
+  const activeCount = notifications.filter((n) => !n.isProcessed).length;
 
-  return {
-    liveNotice,
-    showLiveNotice,
-    notifications,
-    hasUnread,
-    markAsRead,
-  };
+  return { liveNotice, showLiveNotice, notifications, hasUnread, markAsRead, activeCount };
 };

--- a/src/services/MenuService.ts
+++ b/src/services/MenuService.ts
@@ -19,6 +19,7 @@ export interface MenuListItemV3 {
   stock: number;
   is_soldout: boolean;
   is_fixed: boolean;
+  set_items?: { menu_id: number; quantity: number; base_price: number; stock: number }[];
 }
 
 export interface MenuListResponseV3 {
@@ -74,7 +75,7 @@ function mapV3MenuListToBoothMenuData(res: MenuListResponseV3): BoothMenuData {
         set_price: item.price,
         origin_price: item.price,
         is_sold_out: item.is_soldout,
-        menu_items: [],
+        menu_items: (item.set_items ?? []).map((si) => ({ menu_id: si.menu_id, quantity: si.quantity })),
       });
     }
   }
@@ -93,6 +94,7 @@ const MenuService = {
       const response = await instance.get<MenuListResponseV3>(
         '/api/v3/django/booth/menu-list/',
       );
+      console.log('메뉴 리스트 응답:', response.data);
       return mapV3MenuListToBoothMenuData(response.data);
     } catch (error) {
       throw error;


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

- 세트메뉴 수정 모달에서 메뉴구성이 표시되지 않던 버그 수정 — BE 응답의 set_items 필드를 menu_items로 매핑
- 헤더 벨 알림 WS 연동 준비 — 더미 데이터 제거 후 실제 StaffCallWsItem 타입 기반으로 리팩토링 (useStaffCall.ts, Bell.tsx, BellModal.tsx)
- LiveNotice 및 WS 연결 비활성화 (필요없어져서 일단 비활성화 추후 삭제예정 )
- Spring Boot WebSocketConfig.java CORS 누락 수정 — /ws/server/staffcall 핸들러에 https://localhost:5173 추가

## 📸 Screenshot

<!-- 작업한 화면의 스크린 샷 -->

<img width="1618" height="792" alt="어드민 알림 야르 " src="https://github.com/user-attachments/assets/22fdcd69-d3c4-4076-bb27-f7fb7840b6f1" />

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #61
