### PR TITLE
🐛 [Fix] #61 - 메뉴삭제 토스트메세지 추가, 사용된쿠폰ui수정

### DIFF
--- a/src/pages/coupon/_components/CouponDetail/CouponDetail.styled.ts
+++ b/src/pages/coupon/_components/CouponDetail/CouponDetail.styled.ts
@@ -121,16 +121,23 @@ export const CouponList = styled.div`
   margin-top: 2rem;
 `;
 
-export const Coupon = styled.div<{ isUsed?: boolean }>`
+export const Coupon = styled.div<{ $isUsed?: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
 
   ${({ theme }) => theme.fonts.SemiBold16};
   min-width: 270px;
-  border: 1px solid ${({ theme }) => theme.colors.Black02};
+  border: 1px solid ${({ $isUsed, theme }) =>
+    $isUsed ? theme.colors.Black02 : theme.colors.Black02};
   border-radius: 20px;
   padding: 15px 17px;
+  opacity: ${({ $isUsed }) => ($isUsed ? 0.45 : 1)};
+`;
+
+export const UsedBadge = styled.span`
+  color: ${({ theme }) => theme.colors.Black02};
+  ${({ theme }) => theme.fonts.SemiBold14};
 `;
 
 export const CouponCode = styled.span<{ $isUsed?: boolean }>`

--- a/src/pages/coupon/_components/CouponDetail/CouponItem.tsx
+++ b/src/pages/coupon/_components/CouponDetail/CouponItem.tsx
@@ -8,9 +8,9 @@ export const CouponItem = ({
   isUsed: boolean;
 }) => {
   return (
-    <S.Coupon>
+    <S.Coupon $isUsed={isUsed}>
       <S.CouponCode $isUsed={isUsed}>{code}</S.CouponCode>
-      {isUsed ? <span>사용됨</span> : <></>}
+      {isUsed && <S.UsedBadge>사용됨</S.UsedBadge>}
     </S.Coupon>
   );
 };

--- a/src/pages/menu/_components/MenuCard.tsx
+++ b/src/pages/menu/_components/MenuCard.tsx
@@ -5,6 +5,8 @@ import MenuDeleteModal from "../../modal_test_view/_components/MenuDeleteModal";
 import { BoothMenuData, Menu } from "../Type/Menu_type";
 import MenuService from "../../../services/MenuService";
 import EditMenuModal from "@pages/modal_test_view/_components/EditMenuModal";
+import { isAxiosError } from "axios";
+import Toast from "@components/ToastMessage/Toast";
 
 interface MenuCardProps {
   menu: Menu;
@@ -15,6 +17,7 @@ interface MenuCardProps {
 const MenuCard = ({ menu, onSuccess, boothMenuData }: MenuCardProps) => {
   const [showModal, setShowModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [toastMsg, setToastMsg] = useState("");
 
   const isSoldOut = menu.is_sold_out;
 
@@ -39,9 +42,14 @@ const MenuCard = ({ menu, onSuccess, boothMenuData }: MenuCardProps) => {
     try {
       await MenuService.deleteMenu(menu.menu_id);
       setShowDeleteModal(false);
-      onSuccess((prev) => !prev); // 목록 새로고침
+      onSuccess((prev) => !prev);
     } catch (error) {
-      alert("메뉴 삭제에 실패했습니다.");
+      setShowDeleteModal(false);
+      if (isAxiosError(error) && error.response?.status === 400) {
+        setToastMsg("주문이 들어가 있는 메뉴는 삭제가 불가능합니다!");
+      } else {
+        setToastMsg("메뉴 삭제에 실패했습니다!");
+      }
     }
   };
 
@@ -123,6 +131,14 @@ const MenuCard = ({ menu, onSuccess, boothMenuData }: MenuCardProps) => {
           onDelete={handleConfirmDelete}
         />
       )}
+
+      <Toast
+        message={toastMsg}
+        isVisible={!!toastMsg}
+        onClose={() => setToastMsg("")}
+        icon={IMAGE_CONSTANTS.TOAST_ERROR}
+        variant="error"
+      />
     </>
   );
 };

--- a/src/pages/menu/_components/SetMenuCard.tsx
+++ b/src/pages/menu/_components/SetMenuCard.tsx
@@ -5,6 +5,8 @@ import EditSetMenuModal from "../../modal_test_view/_components/EditSetMenuModal
 import MenuDeleteModal from "../../modal_test_view/_components/MenuDeleteModal";
 import { BoothMenuData, SetMenu } from "../Type/Menu_type";
 import MenuService from "@services/MenuService";
+import { isAxiosError } from "axios";
+import Toast from "@components/ToastMessage/Toast";
 
 interface SetMenuCardProps {
   menu: SetMenu;
@@ -19,6 +21,7 @@ const SetMenuCard = ({
 }: SetMenuCardProps) => {
   const [showModal, setShowModal] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [toastMsg, setToastMsg] = useState("");
 
   const isSoldOut = menu.is_sold_out;
 
@@ -42,9 +45,14 @@ const SetMenuCard = ({
     try {
       await MenuService.deleteSetMenu(menu.set_menu_id);
       setShowDeleteModal(false);
-      onMenuChange(); // 목록 새로고침
+      onMenuChange();
     } catch (error) {
-      alert("메뉴 삭제에 실패했습니다.");
+      setShowDeleteModal(false);
+      if (isAxiosError(error) && error.response?.status === 400) {
+        setToastMsg("주문이 들어가 있는 메뉴는 삭제가 불가능합니다!");
+      } else {
+        setToastMsg("메뉴 삭제에 실패했습니다!");
+      }
     }
   };
 
@@ -101,6 +109,14 @@ const SetMenuCard = ({
           onDelete={handleConfirmDelete}
         />
       )}
+
+      <Toast
+        message={toastMsg}
+        isVisible={!!toastMsg}
+        onClose={() => setToastMsg("")}
+        icon={IMAGE_CONSTANTS.TOAST_ERROR}
+        variant="error"
+      />
     </>
   );
 };


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
- 일반 메뉴 / 세트메뉴 삭제 시 에러 응답별 토스트 메시지 처리
400 (활성 주문 있음) → "주문이 들어가 있는 메뉴는 삭제가 불가능합니다!"
그 외 에러 → "메뉴 삭제에 실패했습니다!"
기존 alert() 제거 → Toast 컴포넌트로 교체
- 쿠폰 상세 사용된 쿠폰 시각적 개선
사용된 쿠폰 항목 전체 opacity: 0.45 적용으로 미사용 쿠폰과 명확히 구분
"사용됨" 텍스트 UsedBadge 스타일 컴포넌트로 분리

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #61 
