### PR TITLE
[Fix] #79 - 1차 QA에 대해서 2차 수정을 진행한다.

### DIFF
--- a/src/constants/imageConstants.ts
+++ b/src/constants/imageConstants.ts
@@ -61,7 +61,7 @@ export const IMAGE_CONSTANTS = {
   LOGO: '/images/LogoV3.png',
   LOGO2: '/images/Logo2V3.png',
   CHARACTER: '/images/CharacterV3.png',
-  NOMALCHARACTER: '/images/NomalCharacterV3.png',
+  NOMALCHARACTER: LOGOIMAGE,
   SIDECHARACTER: '/images/SideLogoV3.png',
 
   FOOD_PIZZA: 'https://cdn-icons-png.flaticon.com/512/6978/6978255.png',

--- a/src/pages/orderlistpage/compoenents/amountBox/AmountBox.styled.ts
+++ b/src/pages/orderlistpage/compoenents/amountBox/AmountBox.styled.ts
@@ -20,12 +20,12 @@ export const SectionTitle = styled.h2`
   gap: 0.5rem;
   margin: 0;
   ${({ theme }) => theme.fonts.Medium16};
-  color: '#888888';
+  color: ${({ theme }) => theme.colors.Gray03};
 `;
 
 export const SectionTitleIcon = styled.span`
   display: flex;
-  color: ${({ theme }) => theme.colors.Gray02};
+  color: ${({ theme }) => theme.colors.Gray03};
 `;
 
 export const SectionList = styled.ul`

--- a/src/pages/signup/_components/modals/signupcomplete/SignupComplete.tsx
+++ b/src/pages/signup/_components/modals/signupcomplete/SignupComplete.tsx
@@ -22,7 +22,7 @@ const SignupComplete = () => {
           </S.LogoWrapper>
         </S.ModalTop>
         <S.ToLogin onClick={() => navigate(ROUTE_PATHS.LOGIN)}>
-          로그인 하러 가기
+          로그인하러 가기
         </S.ToLogin>
       </S.ModalWrap>
     </S.Wrapper>

--- a/src/pages/signup/_components/pubinfoform/PubInfoForm.tsx
+++ b/src/pages/signup/_components/pubinfoform/PubInfoForm.tsx
@@ -21,11 +21,12 @@ type Props = {
 
 const isValidPubName = (name: string) => {
   const trimmed = name.trim();
-  return /^[가-힣a-zA-Z0-9 ]{1,20}$/.test(trimmed);
+  // 완성형 한글 + 호환 자모(초성·중성·종성 단독 입력) + 영숫자·공백
+  return /^[가-힣\u3131-\u318Ea-zA-Z0-9 ]{1,20}$/.test(trimmed);
 };
 const isValidTableCount = (value: string) => {
   const number = Number(value);
-  return Number.isInteger(number) && number >= 1 && number <= 100;
+  return Number.isInteger(number) && number >= 1 && number <= 200;
 };
 const isValidTableFee = (value: string) => {
   const number = Number(value);
@@ -52,7 +53,7 @@ const PubInfoForm = ({
   const [pubNameSuccess, setPubNameSuccess] = useState<string | null>(null);
   const [tableCountError, setTableCountError] = useState<string | null>(null);
   const [tableCountSuccess, setTableCountSuccess] = useState<string | null>(
-    null
+    null,
   );
   const [tableFeeError, setTableFeeError] = useState<string | null>(null);
   const [tableFeeSuccess, setTableFeeSuccess] = useState<string | null>(null);
@@ -60,21 +61,21 @@ const PubInfoForm = ({
   // ---- 유효성(Boolean) 계산 ----
   const isPubNameValid = useMemo(
     () => !!pubName && isValidPubName(pubName),
-    [pubName]
+    [pubName],
   );
   const isTableCountValid = useMemo(
     () => !!tableCount && isValidTableCount(tableCount),
-    [tableCount]
+    [tableCount],
   );
 
   // 정책이 NO면 이용료는 비검증/비필수
   const isTableFeeRequired = useMemo(
     () => pubStage >= 2 && tableFeePolicy !== 'NO',
-    [pubStage, tableFeePolicy]
+    [pubStage, tableFeePolicy],
   );
   const isTableFeeValid = useMemo(
     () => !isTableFeeRequired || (!!tableFee && isValidTableFee(tableFee)),
-    [isTableFeeRequired, tableFee]
+    [isTableFeeRequired, tableFee],
   );
 
   const isFirstValid = isPubNameValid && isTableCountValid;
@@ -102,7 +103,7 @@ const PubInfoForm = ({
                 setPubNameSuccess('사용 가능한 주점명이에요!');
               } else {
                 setPubNameError(
-                  '1~20자 이내의 한글, 영문, 숫자를 입력해 주세요.'
+                  '1~20자 이내의 한글, 영문, 숫자를 입력해 주세요.',
                 );
                 setPubNameSuccess(null);
               }
@@ -133,13 +134,13 @@ const PubInfoForm = ({
                 setTableCountError(null);
                 setTableCountSuccess('사용 가능한 테이블 개수에요!');
               } else {
-                setTableCountError('1~100 사이의 숫자를 입력해 주세요.');
+                setTableCountError('1~200 사이의 숫자를 입력해 주세요.');
                 setTableCountSuccess(null);
               }
             }}
             error={tableCountError ?? undefined}
             success={tableCountSuccess ?? undefined}
-            helperText="1~100 사이의 숫자만 입력할 수 있어요."
+            helperText="1~200 사이의 숫자만 입력할 수 있어요."
             onClear={() => {
               onChange('tableCount', '');
               setTableCountError(null);
@@ -181,9 +182,11 @@ const PubInfoForm = ({
                 setTableFeeSuccess(null);
               }
             }}
-            error={isTableFeeRequired ? tableFeeError ?? undefined : undefined}
+            error={
+              isTableFeeRequired ? (tableFeeError ?? undefined) : undefined
+            }
             success={
-              isTableFeeRequired ? tableFeeSuccess ?? undefined : undefined
+              isTableFeeRequired ? (tableFeeSuccess ?? undefined) : undefined
             }
             helperText={
               isTableFeeRequired

--- a/src/pages/signup/_components/userinfoform/UserInfoForm.tsx
+++ b/src/pages/signup/_components/userinfoform/UserInfoForm.tsx
@@ -142,7 +142,6 @@ const UserInfoForm = ({
           setConfirmPwSuccess(null);
         }}
         isVisible={userStage >= 3}
-        forceShowPasswordWhenSuccess
         disabled={userStage !== 3}
       />
 

--- a/src/pages/signup/_hooks/useSignupPage.ts
+++ b/src/pages/signup/_hooks/useSignupPage.ts
@@ -69,7 +69,7 @@ export const useSignupPage = (
           seat_type: seatType,
           seat_fee_person: seatType === 'PP' ? Number(formData.tableFee) : 0,
           seat_fee_table: seatType === 'PT' ? Number(formData.tableFee) : 0,
-          table_limit_hours: Number(formData.maxTime),
+          table_limit_hours: Number(formData.maxTime) / 60,
         },
       });
       // 회원가입 성공 시: 추가 호출(자동 로그인)이나 로컬 저장 없이 완료 모달만 노출

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -20,6 +20,7 @@ declare module 'styled-components' {
       Highlight: string;
       Gray01: string;
       Gray02: string;
+      Gray03: string;
 
       // 텍스트 색상
       Black01: string;

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -32,6 +32,7 @@ const colors = {
   Highlight: '#BE5D3A',
   Gray01: '#F2F2F2',
   Gray02: '#AFAFAF',
+  Gray03: '#888888',
 
   // 텍스트 색상
   Black01: '#2A2A2A',


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
- 회원가입 플로우 QA 반영: 캐릭터·완료 모달 문구, 비밀번호 확인 UX, 주점명·테이블 수 입력 규칙, 이용 시간 API 단위
- 주문 목록 우측 사이드바(금액 박스) 섹션 타이틀·아이콘 색상을 테마 Gray03 기준으로 통일

## 📍 PR Point

<!-- 자랑하고 싶은 부분!  -->

table_limit_hours: 드롭다운 분 단위 값을 **시간(소수)**으로 변환해 전송해 백엔드 검증(정수·소수 자릿수)과 맞춤
주점명에 한글 호환 자모(초성 등) 입력 허용으로 IME 단계 입력도 통과
비밀번호 확인 일치 시 자동으로 평문 노출되지 않도록 변경 (마스킹 유지, 토글만으로 표시)
테이블 개수 1~200으로 상한 확대 및 안내 문구 정합
사이드바 타이틀에 하드코딩된 '#888888' 제거하고 **theme.colors.Gray03**로 정리

## 📢 Notices

<!--공용으로 사용하는 부분에 대한 설명-->

theme.colors.Gray03 (#888888)를 styled.d.ts에 추가했습니다. 동일 톤의 회색이 필요하면 Gray03을 쓰면 됩니다.
**IMAGE_CONSTANTS.NOMALCHARACTER**가 LOGOIMAGE를 참조하도록 바뀌었습니다. 회원가입 등 해당 상수를 쓰는 화면에서 이미지 출처가 동일 계열로 맞춰집니다.

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

#79
