### PR TITLE
🐛 [Fix] #61 - 부스명 api 변경해서 연결,부스id사용삭제, 메뉴쿠폰버튼 ui 수정 

### DIFF
--- a/src/components/header/hooks/useBoothRevenue.ts
+++ b/src/components/header/hooks/useBoothRevenue.ts
@@ -133,14 +133,8 @@ const useBoothRevenue = () => {
     let aborted = false;
 
     const fetchBoothName = async () => {
-      const boothId =
-        localStorage.getItem('Booth-ID') ?? localStorage.getItem('boothId');
-      if (!boothId) {
-        setError('부스 정보가 없습니다.');
-        return;
-      }
       try {
-        const response = await BoothService.getBoothName(boothId);
+        const response = await BoothService.getBoothName();
         if (aborted) return;
         if (response?.data?.booth_name) {
           setError(null);

--- a/src/pages/coupon/_components/CouponRegisterModal.tsx
+++ b/src/pages/coupon/_components/CouponRegisterModal.tsx
@@ -95,7 +95,7 @@ export const CouponRegisterModal = ({ onClose }: { onClose: () => void }) => {
           취소
         </S.BottomBtn>
         <S.BottomBtn type='submit' disabled={!isReady} onClick={handleSubmit}>
-          쿠폰등록
+          쿠폰 등록
         </S.BottomBtn>
       </S.BottomBtnContainer>
     </S.Wrapper>

--- a/src/pages/modal_test_view/_components/styled.ts
+++ b/src/pages/modal_test_view/_components/styled.ts
@@ -6,7 +6,7 @@ export const Wrapper = styled.form`
   width: 80%;
 
   display: grid;
-  grid-template-rows: 12fr 1fr;
+  grid-template-rows: 1fr auto;
 
   z-index: 10;
   background-color: ${({ theme }) => theme.colors.Gray01};
@@ -193,16 +193,18 @@ export const ModalConfirmContainer = styled.div`
   display: flex;
   flex-direction: row;
   border-top: 1px solid ${({ theme }) => theme.colors.Black02};
+
   button {
     width: 100%;
     box-sizing: border-box;
-    padding: 0.75rem 3rem;
+    padding: 1.25rem 3rem;
     display: flex;
     justify-content: center;
     align-items: center;
     color: ${({ theme }) => theme.colors.Orange01};
     &:disabled {
-      color: ${({ theme }) => theme.colors.Black02};
+      ${({ theme }) => theme.fonts.SemiBold16}
+      color: ${({ theme }) => theme.colors.Gray02};
     }
   }
   button:nth-child(1) {
@@ -210,6 +212,9 @@ export const ModalConfirmContainer = styled.div`
     border-right: 1px solid ${({ theme }) => theme.colors.Black02};
   }
   button:nth-child(2) {
+    &:disabled {
+      ${({ theme }) => theme.fonts.SemiBold16}
+    }
     ${({ theme }) => theme.fonts.ExtraBold16}
   }
 `;

--- a/src/services/BoothService.ts
+++ b/src/services/BoothService.ts
@@ -5,18 +5,11 @@ export interface BoothNameResponse {
   data: { booth_name: string };
 }
 
-/**
- * 부스 관련 API 서비스
- */
 const BoothService = {
-  /**
-   * 부스 이름 조회 (GET /api/v3/django/booth/{booth_id}/name/)
-   */
-  getBoothName: async (
-    boothId: number | string,
-  ): Promise<BoothNameResponse> => {
+  // GET /api/v3/django/booth/name/ — 쿠키 인증, booth_id 불필요
+  getBoothName: async (): Promise<BoothNameResponse> => {
     const response = await instance.get<BoothNameResponse>(
-      `/api/v3/django/booth/${boothId}/name/`,
+      '/api/v3/django/booth/name/',
     );
     return response.data;
   },


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->
어드민에서는 부스id를 사용할 이유가 없는데 사용하고있었어서 부스id없이 이름을 불러오는 api를 백엔드에서 새로 구현하고 프론트도 그에 맞춰서 연결했습니다. 

부스id사용하는 로직은 삭제했습니다. 

메뉴생성모달, 쿠폰등록모달에서 ui 수정했습니다. 

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #61 
