### PR TITLE
[Fix] #92 - 이미지 용량 제한 수정

### DIFF
--- a/src/pages/modal_test_view/_components/EditMenuModal.tsx
+++ b/src/pages/modal_test_view/_components/EditMenuModal.tsx
@@ -22,7 +22,7 @@ interface EditModalProps {
 }
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 업로드 이미지 크기 제한 10MB
-const MIN_FILE_SIZE = 2.5 * 1024 * 1024;
+const MIN_FILE_SIZE = 1 * 1024 * 1024;
 
 const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
   const [UploadImg, setUploadImg] = useState<string | null>(null);
@@ -173,8 +173,8 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
       <S.ModalBody>
         <S.ModalHeader>
           메뉴 수정
-          <button type='button' onClick={handleCloseModal}>
-            <img src={IMAGE_CONSTANTS.CLOSE} alt='닫기' />
+          <button type="button" onClick={handleCloseModal}>
+            <img src={IMAGE_CONSTANTS.CLOSE} alt="닫기" />
           </button>
         </S.ModalHeader>
         <S.FormContentWrapper>
@@ -183,8 +183,8 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
               메뉴명<span>*</span>
             </S.SubTitle>
             <S.inputText
-              type='text'
-              placeholder='예) 피자'
+              type="text"
+              placeholder="예) 피자"
               value={name}
               onChange={(e) => setName(e.target.value)}
               maxLength={20}
@@ -193,8 +193,8 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
           <S.ele>
             <S.SubTitle>메뉴 설명</S.SubTitle>
             <S.inputText
-              type='text'
-              placeholder='예) 이탈리아의 풍미를 잔뜩 느낄 수 있는 피자에요.'
+              type="text"
+              placeholder="예) 이탈리아의 풍미를 잔뜩 느낄 수 있는 피자에요."
               value={desc}
               onChange={(e) => setDesc(e.target.value)}
               maxLength={30}
@@ -205,8 +205,8 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
               메뉴 가격<span>*</span>
             </S.SubTitle>
             <S.inputText
-              type='text'
-              placeholder='예) 20000'
+              type="text"
+              placeholder="예) 20000"
               value={price}
               onChange={handlePriceChange}
               onInput={HandleNumberInput}
@@ -217,8 +217,8 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
               재고수량<span>*</span>
             </S.SubTitle>
             <S.inputText
-              type='number'
-              placeholder='예) 100'
+              type="number"
+              placeholder="예) 100"
               value={stock}
               onChange={handleStockChange}
               onInput={HandleNumberInput}
@@ -230,9 +230,9 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
             {/* V3 수정 시 이미지 변경 미지원 — label→div로 교체해 파일 업로드 비활성화 */}
             <div>
               <S.inputImg
-                id='file-upload'
-                type='file'
-                accept='.jpg,.png,.jpeg'
+                id="file-upload"
+                type="file"
+                accept=".jpg,.png,.jpeg"
                 onChange={handleFileChange}
                 multiple={false}
                 ref={fileInputRef}
@@ -240,7 +240,7 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
               />
               {UploadImg ? (
                 <S.ImgContainer>
-                  <S.Img src={UploadImg} alt='첨부한 이미지' />
+                  <S.Img src={UploadImg} alt="첨부한 이미지" />
                   {/* V3 이미지 삭제 비활성화 — 수정 시 이미지 변경/삭제 미지원 */}
                   {/* <button
                     type="button"
@@ -255,7 +255,7 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
                 </S.ImgContainer>
               ) : (
                 <S.DefaultImgBox>
-                  <img src={IMAGE_CONSTANTS.NOMALCHARACTER} alt='기본 이미지' />
+                  <img src={IMAGE_CONSTANTS.NOMALCHARACTER} alt="기본 이미지" />
                 </S.DefaultImgBox>
               )}
             </div>
@@ -263,10 +263,10 @@ const EditMenuModal = ({ handleCloseModal, defaultValues }: EditModalProps) => {
         </S.FormContentWrapper>
       </S.ModalBody>
       <S.ModalConfirmContainer>
-        <button type='button' onClick={handleCloseModal}>
+        <button type="button" onClick={handleCloseModal}>
           취소
         </button>
-        <button type='submit' disabled={buttonDisable}>
+        <button type="submit" disabled={buttonDisable}>
           메뉴 수정
         </button>
       </S.ModalConfirmContainer>

--- a/src/pages/modal_test_view/_components/MenuModal.tsx
+++ b/src/pages/modal_test_view/_components/MenuModal.tsx
@@ -24,7 +24,7 @@ interface MenuModalProps {
 }
 
 const MAX_FILE_SIZE = 10 * 1024 * 1024; // 업로드 이미지 크기 제한 10MB
-const MIN_FILE_SIZE = 2.5 * 1024 * 1024;
+const MIN_FILE_SIZE = 1 * 1024 * 1024;
 
 type SetItem = {
   menuId: number | null;
@@ -195,7 +195,10 @@ const MenuModal = ({ handleCloseModal, boothMenuData }: MenuModalProps) => {
 
         await MenuServiceWithImg.createSetMenu(formData);
       } else {
-        const categoryMap: Record<string, string> = { '메뉴': 'MENU', '음료': 'DRINK' };
+        const categoryMap: Record<string, string> = {
+          메뉴: 'MENU',
+          음료: 'DRINK',
+        };
         const formData = new FormData();
         formData.append('name', name);
         formData.append('description', desc || '');


### PR DESCRIPTION
## 🔍 What is the PR?

- 메뉴 이미지 업로드 시 발생하던 `415 Unsupported Media Type` 대응  
- 메뉴 등록/수정 모달에서 이미지 압축 분기 기준(`MIN_FILE_SIZE`) 조정  
  - 일부 크기 구간에서 압축 없이 원본만 전송되던 경우를 줄이고, 업로드 성공 패턴과 맞추기 위함  
- `browser-image-compression` 기반 압축 옵션(`maxSizeMB`, `maxWidthOrHeight` 등)은 유지  

## 💭 Related Issues

#92