### PR TITLE
🐛 [Fix] #104 - stripStaleCsrfCookies() 함수 전체 삭제

### DIFF
--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -51,30 +51,7 @@ const isUnsafeMethod = (method?: string) => {
   return !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(m);
 };
 
-// 백엔드가 host-only 쿠키로 전환된 이후에도 과거에 부모 도메인으로 박힌 잔재 쿠키가
-// 브라우저에 남아 있으면 csrftoken이 두 개가 되어 CSRF 검증이 깨진다.
-// 백엔드 clear_stale_domain_cookies helper가 99% 처리하지만, JS 측에서도 한 번 더
-// 알려진 옛 Domain 변형들로 expire 시도해 안전망을 한다 (지울 수 없으면 no-op).
-const stripStaleCsrfCookies = () => {
-  const past = 'expires=Thu, 01 Jan 1970 00:00:00 GMT';
-  const domains = [
-    '.dorder-api.shop',
-    'dorder-api.shop',
-    'dev.dorder-api.shop',
-    '.dev.dorder-api.shop',
-    'prod.dorder-api.shop',
-    '.prod.dorder-api.shop',
-  ];
-  const names = ['csrftoken', 'sessionid'];
-  for (const d of domains) {
-    for (const n of names) {
-      document.cookie = `${n}=; ${past}; path=/; domain=${d}`;
-    }
-  }
-};
-
 const fetchCsrfToken = async (): Promise<string | null> => {
-  stripStaleCsrfCookies();
   const res = await instance.get('/api/v3/django/auth/csrf-token/');
   const token = res.data?.csrfToken;
   return typeof token === 'string' ? token : null;


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

- stripStaleCsrfCookies() 함수 전체 삭제 — document.cookie로 .dorder-api.shop 도메인의 옛 csrftoken/sessionid 쿠키를 지우려던 함수. 브라우저 보안 규칙상 FE 오리진(localhost/netlify)에서는 남의 도메인(.dorder-api.shop) 쿠키를 못 지워서 실제로는 아무 동작도 안 하던 죽은 코드였음.
- fetchCsrfToken() 안의 호출 한 줄 삭제 — 위 함수 호출 제거. csrf-token GET → res.data.csrfToken 반환 로직은 그대로.


## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #104
