### PR TITLE
[Fix] #129 - 주문 목록 WS 단일 소스 동기화 및 잘못된 주문 삭제 수정

### DIFF
--- a/src/pages/orderlistpage/OrderListPage.tsx
+++ b/src/pages/orderlistpage/OrderListPage.tsx
@@ -6,13 +6,11 @@ import OrderList from './compoenents/OrderList/OrderList';
 import AmountBox from './compoenents/amountBox/AmountBox';
 import type { AmountItem } from './compoenents/amountBox/AmountBox';
 import type { OrderBoxData } from './compoenents/orderbox/OrderBox';
-import type { OrderStatus } from './compoenents/orderboxitem/OrderBoxItem.styled';
 import type { EditableStatus } from './compoenents/orderboxitem/OrderBoxItem';
 import { useOrderManagementWebSocket } from './hooks/useOrderManagementWebSocket';
 import { updateOrderItemStatus } from './apis/updateOrderItemStatus';
 import type { OrderItemTargetStatus } from './utils/mapEditableStatusToApiStatus';
 import { mapEditableStatusToApiStatus } from './utils/mapEditableStatusToApiStatus';
-import { mapStatus } from './utils/mapSnapshotToOrderBoxData';
 import { getNextStatus } from './utils/getNextStatus';
 
 export default function OrderListPage() {
@@ -32,22 +30,11 @@ export default function OrderListPage() {
   const statusSubmittingRef = useRef(false);
 
   /**
-   * 공통 상태 변경 로직: API 호출 → 낙관적 UI 업데이트
-   * handleOrderItemClick과 handleStatusSelect에서 공유
+   * 상태 변경: PATCH만 호출하고 UI는 WS(ADMIN_ORDER_UPDATE / ADMIN_ORDER_COMPLETED)에 맡김.
+   * (PATCH 직후 tableIndex 기반 로컬 갱신·삭제는 목록이 밀릴 때 다른 통까지 지우는 원인)
    */
   const executeStatusChange = useCallback(
-    async (
-      tableIndex: number,
-      itemIndex: number,
-      targetStatus: OrderItemTargetStatus,
-    ) => {
-      const orderItemId = orders[tableIndex]?.items[itemIndex]?.id;
-
-      if (orderItemId == null) {
-        alert('order_item_id가 없어 상태를 변경할 수 없습니다.');
-        return;
-      }
-
+    async (orderItemId: number, targetStatus: OrderItemTargetStatus) => {
       if (statusSubmittingRef.current) return;
       statusSubmittingRef.current = true;
 
@@ -62,37 +49,7 @@ export default function OrderListPage() {
           target_status: targetStatus,
         });
 
-        const d = res.data;
-        const nextUiStatus: OrderStatus = d?.status
-          ? mapStatus(d.status)
-          : (mapStatus(targetStatus) as OrderStatus);
-
-        console.log('[OrderList] 상태 변경 응답', res);
-
-        if (d?.all_items_served) {
-          setOrders((prev) => {
-            const oid = prev[tableIndex]?.orderId;
-            if (oid != null) {
-              return prev.filter((box) => box.orderId !== oid);
-            }
-            return prev.filter((_, i) => i !== tableIndex);
-          });
-        } else {
-          setOrders((prev) =>
-            prev.map((tableRow, ti) =>
-              ti !== tableIndex
-                ? tableRow
-                : {
-                    ...tableRow,
-                    items: tableRow.items.map((rowItem, ii) =>
-                      ii !== itemIndex
-                        ? rowItem
-                        : { ...rowItem, status: nextUiStatus },
-                    ),
-                  },
-            ),
-          );
-        }
+        console.log('[OrderList] 상태 변경 요청 완료 (UI는 WS 반영)', res);
       } catch (err) {
         let message = '상태 변경에 실패했습니다.';
         if (isAxiosError(err)) {
@@ -107,7 +64,7 @@ export default function OrderListPage() {
         statusSubmittingRef.current = false;
       }
     },
-    [orders],
+    [],
   );
 
   /** 단일 클릭: 상태 자동 전진 (조리중→조리완료, 조리완료→서빙완료) */
@@ -118,8 +75,12 @@ export default function OrderListPage() {
 
       const nextApiStatus = getNextStatus(item.status);
       if (nextApiStatus == null) return; // 서빙중/서빙완료 등 전진 불가
+      if (item.id == null) {
+        alert('order_item_id가 없어 상태를 변경할 수 없습니다.');
+        return;
+      }
 
-      await executeStatusChange(tableIndex, itemIndex, nextApiStatus);
+      await executeStatusChange(item.id, nextApiStatus);
     },
     [orders, executeStatusChange],
   );
@@ -138,12 +99,19 @@ export default function OrderListPage() {
       if (openTarget == null) return;
 
       const { tableIndex, itemIndex } = openTarget;
+      const orderItemId = orders[tableIndex]?.items[itemIndex]?.id;
+      if (orderItemId == null) {
+        alert('order_item_id가 없어 상태를 변경할 수 없습니다.');
+        setOpenTarget(null);
+        return;
+      }
+
       const targetStatus = mapEditableStatusToApiStatus(newStatus);
 
       setOpenTarget(null);
-      await executeStatusChange(tableIndex, itemIndex, targetStatus);
+      await executeStatusChange(orderItemId, targetStatus);
     },
-    [openTarget, executeStatusChange],
+    [openTarget, orders, executeStatusChange],
   );
 
   const handleModalClose = useCallback(() => {

--- a/src/pages/orderlistpage/utils/applyOrderCompleted.ts
+++ b/src/pages/orderlistpage/utils/applyOrderCompleted.ts
@@ -9,9 +9,9 @@ export function applyOrderCompleted(
   prev: OrderBoxData[],
   data: OrderCompletedPayload
 ): OrderBoxData[] {
-  const completedId = data.order_id;
+  const completedId = Number(data.order_id);
   return prev.filter((box) => {
-    if (box.orderId != null) return box.orderId !== completedId;
+    if (box.orderId != null) return Number(box.orderId) !== completedId;
     // 레거시(평면 스냅샷 등 orderId 없음): 테이블 단위로만 구분
     return Number(box.tableNumber) !== Number(data.table_num);
   });

--- a/src/pages/orderlistpage/utils/applyOrderUpdate.ts
+++ b/src/pages/orderlistpage/utils/applyOrderUpdate.ts
@@ -36,14 +36,15 @@ export function applyOrderUpdate(
   const patchMap = collectPatches(data);
   if (patchMap.size === 0) return prev;
 
-  const targetOrderId = data.order_id;
+  const targetOrderId =
+    data.order_id != null ? Number(data.order_id) : undefined;
 
   return prev
     .map((table) => {
       if (
         table.orderId != null &&
         targetOrderId != null &&
-        table.orderId !== targetOrderId
+        Number(table.orderId) !== targetOrderId
       ) {
         return table;
       }


### PR DESCRIPTION
## 🔍 What is the PR?

- 메인 주문 목록(`OrderListPage`)에서 PATCH 성공 후 `tableIndex`로 `setOrders` 하던 **낙관적 UI 갱신·주문 삭제 로직 제거**
- 주문 줄/전체 상태·삭제는 **WebSocket** (`ADMIN_ORDER_UPDATE`, `ADMIN_ORDER_COMPLETED`)만 반영하도록 변경
- `executeStatusChange`가 `tableIndex` 대신 **`order_item_id`만** 서버에 전달하도록 수정 (비동기 응답 시 목록이 밀린 뒤 다른 주문이 지워지던 문제 방지)
- `applyOrderUpdate`, `applyOrderCompleted`에서 **`order_id` 숫자 비교**로 대상 주문 매칭 안정화


## 📍 PR Point

- PATCH와 WS가 동시에 `orders` state를 수정하며 **인덱스가 밀린 뒤 엉뚱한 주문이 삭제**되던 원인을 제거
- UI 갱신 경로를 WS 단일 소스로 통일해, 서버가 보내는 `ADMIN_ORDER_UPDATE`(줄 단위) / `ADMIN_ORDER_COMPLETED`(주문 제거)와 일치
- 상태 변경 API는 **명령만** 보내고, 화면 반영은 ID 기반 WS 핸들러에 위임

## 📢 Notices

- 탭 직후 UI는 **WS 도착 시점**에 바뀝니다 (예전처럼 PATCH 응답 직후 즉시 반영되지 않음)
- WS 미수신 시 화면이 갱신되지 않을 수 있어, 네트워크/WS 연결 상태 확인이 필요합니다
- 집계(`MENU_AGGREGATION`) 동작은 기존과 동일합니다

## 💭 Related Issues

- #129