### PR TITLE
🐛 [Fix] #104 - 어드민 동시로그인 csrf요청 에러 수정

### DIFF
--- a/src/services/instance.ts
+++ b/src/services/instance.ts
@@ -34,6 +34,9 @@ export const instatnceWithImg: AxiosInstance = axios.create({
 const isCsrfTokenEndpoint = (url?: string) =>
   url?.includes('/api/v3/django/auth/csrf-token/');
 
+const isDjangoAuthEndpoint = (url?: string) =>
+  url?.includes('/api/v3/django/auth/');
+
 /**
  * 로그인·회원가입 등 아직 로그인되지 않은 상태의 auth 요청.
  * 이 경로에서 오는 401은 "비밀번호 틀림" 등이므로 refresh/location.href 로그인 이동을 하면 안 됨.
@@ -51,10 +54,20 @@ const isUnsafeMethod = (method?: string) => {
   return !['GET', 'HEAD', 'OPTIONS', 'TRACE'].includes(m);
 };
 
-const fetchCsrfToken = async (): Promise<string | null> => {
-  const res = await instance.get('/api/v3/django/auth/csrf-token/');
-  const token = res.data?.csrfToken;
-  return typeof token === 'string' ? token : null;
+let inflightCsrfFetch: Promise<string | null> | null = null;
+
+const fetchCsrfToken = (): Promise<string | null> => {
+  if (inflightCsrfFetch) return inflightCsrfFetch;
+  inflightCsrfFetch = instance
+    .get('/api/v3/django/auth/csrf-token/')
+    .then((res) => {
+      const token = res.data?.csrfToken;
+      return typeof token === 'string' ? token : null;
+    })
+    .finally(() => {
+      inflightCsrfFetch = null;
+    });
+  return inflightCsrfFetch;
 };
 
 // ============================================
@@ -64,7 +77,7 @@ const v3RequestInterceptor = async (config: InternalAxiosRequestConfig) => {
   const isV3Request = config.url?.includes('/api/v3/');
 
   // V3 unsafe 메서드일 때 CSRF 토큰 주입
-  if (isV3Request && isUnsafeMethod(config.method) && !isCsrfTokenEndpoint(config.url)) {
+  if (isV3Request && isUnsafeMethod(config.method) && !isCsrfTokenEndpoint(config.url) && !isDjangoAuthEndpoint(config.url)) {
     let csrfToken = document.cookie
       .split('; ')
       .find((row) => row.startsWith('csrftoken='))


### PR DESCRIPTION
## 🔍 What is the PR?

<!-- PR 내용을 리스트로 작성-->

## 📸 Screenshot
문제
여러 명이 동시에 로그인할 때 CSRF 토큰 요청이 pending 상태에서 응답을 받지 못하는 현상이 간헐적으로 발생.

원인 분석
Django 로그인 엔드포인트는 실제로 CSRF를 검증하지 않음에도 불구하고 프론트에서 불필요하게 CSRF를 fetch하고 있었음.

DRF APIView는 as_view()에서 @csrf_exempt 자동 적용 → Django 미들웨어 CSRF 검증 우회
AuthAPIView는 authentication_classes = [] → JWTCookieAuthentication도 타지 않음
결과적으로 /api/v3/django/auth/* 는 CSRF가 불필요하지만, 브라우저에 csrftoken 쿠키가 없을 때(신규 기기/브라우저) 매 로그인마다 CSRF GET을 먼저 쏘고 있었음
수정 내용
src/services/instance.ts

isDjangoAuthEndpoint 조건 추가: /api/v3/django/auth/* 엔드포인트는 CSRF fetch 스킵
inflightCsrfFetch 패턴 추가: 동일 브라우저 내 동시 요청 발생 시 CSRF GET 중복 방지
효과
로그인/회원가입/리프레시 시 Django CSRF 호출 0건 (기존: 쿠키 없을 시 1건)
로그인 후 인증된 API 호출(메뉴, 부스 등)은 기존과 동일하게 CSRF 유지

## 💭 Related Issues

<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. -->

- #104
