### PR TITLE
[Fix] #141 - 롱프레스 반영 및 색상 변경

### DIFF
--- a/src/pages/orderlistpage/compoenents/orderboxitem/OrderBoxItem.styled.ts
+++ b/src/pages/orderlistpage/compoenents/orderboxitem/OrderBoxItem.styled.ts
@@ -133,7 +133,7 @@ const menuQuantityStyles: Record<
   서빙중: { font: 'Medium16', color: theme.colors.Gray03 },
   서빙완료: { font: 'Medium16', color: theme.colors.Focused },
   서빙수락: { font: 'SemiBold16', color: theme.colors.Gray03 },
-  조리완료: { font: 'SemiBold16', color: theme.colors.Gray03 },
+  조리완료: { font: 'SemiBold16', color: theme.colors.Black01 },
 };
 
 export const MenuName = styled.span<{ $status: OrderStatus }>`

--- a/src/pages/orderlistpage/compoenents/orderboxitem/OrderBoxItem.tsx
+++ b/src/pages/orderlistpage/compoenents/orderboxitem/OrderBoxItem.tsx
@@ -32,9 +32,9 @@ export type OrderBoxItemProps = {
   menuName: string;
   quantity: number;
   status: OrderStatus;
-  /** 상태 배지 클릭 시 호출 (상태 전진). 서빙중/서빙완료/서빙수락일 땐 동작하지 않음 */
+  /** 상태 배지 짧게 누를 때 (상태 전진). 서빙중/서빙완료/서빙수락일 땐 동작하지 않음 */
   onClick?: () => void;
-  /** 500ms 길게 누르면 호출 (되돌리기 모달). 서빙중일 땐 동작하지 않음 */
+  /** 상태 배지 500ms 길게 누를 때 (되돌리기 모달). 서빙중일 땐 동작하지 않음 */
   onLongPress?: () => void;
   /** 이 항목의 상태 변경 모달이 열려 있는지 */
   isModalOpen?: boolean;
@@ -73,7 +73,6 @@ export default function OrderBoxItem({
   onStatusSelect,
   onModalClose,
 }: OrderBoxItemProps) {
-  /* 클릭 비활성: 서빙중/서빙완료/서빙수락이거나 모달이 열려 있을 때 */
   const isClickDisabled =
     status === '서빙중' ||
     status === '서빙완료' ||
@@ -81,17 +80,21 @@ export default function OrderBoxItem({
     !onClick ||
     !!isAnyModalOpen;
 
-  const longPress = useLongPress(onLongPress ?? (() => {}), {
-    delay: 500,
-    disabled:
-      status === '서빙중' || !onLongPress || (!!isAnyModalOpen && !isModalOpen),
-    clickDisabled: true,
-  });
+  const isLongPressDisabled =
+    status === '서빙중' || !onLongPress || (!!isAnyModalOpen && !isModalOpen);
 
-  const handleStatusBadgeClick = () => {
-    if (isClickDisabled) return;
-    onClick?.();
-  };
+  /** 짧은 탭·롱프레스 모두 배지에서만 (useLongPress가 구분) */
+  const isBadgeInteractive = !isClickDisabled || !isLongPressDisabled;
+
+  const badgePress = useLongPress(onLongPress ?? (() => {}), {
+    delay: 500,
+    disabled: isLongPressDisabled,
+    onClick: () => {
+      if (isClickDisabled) return;
+      onClick?.();
+    },
+    clickDisabled: isClickDisabled,
+  });
 
   const statusButtonRef = useRef<HTMLDivElement>(null);
   const { anchorRect, placement } = useStatusModalAnchor(
@@ -102,7 +105,7 @@ export default function OrderBoxItem({
   return (
     <S.OrderBoxItemWrapper $isModalOpen={isModalOpen}>
       <S.ModalWrapper $isModalOpen={isModalOpen} />
-      <S.ItemInfoHalf {...longPress}>
+      <S.ItemInfoHalf>
         <S.ItemInfo>
           <S.ItemImage>
             {imageUrl ? (
@@ -125,15 +128,14 @@ export default function OrderBoxItem({
         <S.Quantity $status={status}>{quantity}</S.Quantity>
         <S.StatusBadgeWrap
           ref={statusButtonRef}
-          $interactive={!isClickDisabled}
-          role={!isClickDisabled ? 'button' : undefined}
-          tabIndex={!isClickDisabled ? 0 : undefined}
-          onClick={handleStatusBadgeClick}
+          {...badgePress}
+          $interactive={isBadgeInteractive}
+          role={isBadgeInteractive ? 'button' : undefined}
+          tabIndex={isBadgeInteractive ? 0 : undefined}
           onKeyDown={(e) => {
-            if (isClickDisabled) return;
             if (e.key === 'Enter' || e.key === ' ') {
               e.preventDefault();
-              handleStatusBadgeClick();
+              if (!isClickDisabled) onClick?.();
             }
           }}
         >


### PR DESCRIPTION
## 🔍 What is the PR?

- 주문 목록 아이템 **상태 전진(짧은 탭)** · **되돌리기(롱프레스)** 인터랙션을 **상태 배지(`StatusBadgeWrap`)로만** 한정 (#138, #141)
- `useLongPress`를 배지에 적용해 **짧은 탭 = 상태 전진**, **500ms 꾹 누르기 = 되돌리기 모달** 구분 (메뉴명·이미지·수량 영역은 무반응)
- 클릭만 배지로 옮긴 뒤 롱프레스가 왼쪽 메뉴 영역에만 남아 배지에서 되돌리기가 안 되던 문제 수정
- `조리완료` 상태의 왼쪽 메뉴명·수량 글자색을 `Gray03` → `Black01`로 변경 (조리중과 동일하게 진하게 표시)

## 📍 PR Point

- 행 전체 클릭으로 인한 오조작 제거, **배지 하나**로 상태 변경·되돌리기 UX 통일
- `useLongPress` 한 곳에서 탭/롱프레스를 나눠, 별도 `onClick` + 행 롱프레스 이중 처리 제거
- `isBadgeInteractive`로 클릭·롱프레스 가능 상태에만 `cursor: pointer` / `role="button"` 적용

## 📢 Notices

- **배지**에서만 동작합니다. 메뉴 이름·수량·이미지를 눌러도 상태 변경·모달이 열리지 않습니다.
- `서빙중`: 짧은 탭·롱프레스 모두 비활성 / `서빙완료`·`서빙수락`: 짧은 탭만 비활성, 롱프레스로 되돌리기 가능
- 왼쪽 텍스트·배지 pill 색은 각각 `menuQuantityStyles` / `statusStyles` (`OrderBoxItem.styled.ts`)에서 관리

## 💭 Related Issues

- #141